### PR TITLE
Add mastodon.tools

### DIFF
--- a/Using-Mastodon/Apps.md
+++ b/Using-Mastodon/Apps.md
@@ -14,5 +14,6 @@ Some people have started working on apps for the Mastodon API. Here is a list of
 |Tooter|Chrome|<https://github.com/ineffyble/tooter>|[@effy@mastodon.social](https://mastodon.social/users/effy)|
 |tootstream|CLI|<https://github.com/magicalraccoon/tootstream>|[@Raccoon@mastodon.social](https://mastodon.social/users/Raccoon)|
 |HackerNewsBot|CLI|<https://github.com/raymestalez/mastodon-hnbot>|[@rayalez@hackertribe.io](https://hackertribe.io/users/rayalez)|
+|Mastodon.tools|Wordpress|<https://github.com/davidlibeau/mastodon-tools>|[@David@mastodon.xyz](https://mastodon.xyz/users/David)|
 
 If you have a project like this, let me know so I can add it to the list!


### PR DESCRIPTION
A project about various tools including a Wordpress plugin, now ready to download at wordpress.org