### PR TITLE
Use 127.0.0.1 instead of localhost in Sidekiq proxy_pass.

### DIFF
--- a/Running-Mastodon/Production-guide.md
+++ b/Running-Mastodon/Production-guide.md
@@ -61,7 +61,7 @@ server {
     proxy_set_header Proxy "";
     proxy_pass_header Server;
 
-    proxy_pass http://localhost:3000;
+    proxy_pass http://127.0.0.1:3000;
     proxy_buffering off;
     proxy_redirect off;
     proxy_http_version 1.1;


### PR DESCRIPTION
Sidekiq only listens on v4 and using localhost will create
non-usable connections to ::1

Re-creating my earlier pull request from the main repo as requested - https://github.com/tootsuite/mastodon/pull/1313#issuecomment-293331562