### PR TITLE
Revert "Oulipo.social has IPv6 now"

### DIFF
--- a/Using-Mastodon/List-of-Mastodon-instances.md
+++ b/Using-Mastodon/List-of-Mastodon-instances.md
@@ -74,7 +74,7 @@ There is also a list at [instances.mastodon.xyz](https://instances.mastodon.xyz)
 | [manx.social](https://manx.social/)|Instance for the Isle of Man|Yes|Yes|
 | [mastodon.host](https://mastodon.host/)|Lightly moderated, federates everywhere and has a follow bot ( Huge federated timeline )|Yes|No|
 | [mastodon.fun](https://mastodon.fun/)|Mastodon for everyone ! |Yes|Yes|
-| [oulipo.social](https://oulipo.social/)|An Oulipo Mastodon in which that fifth symbol in Latin script is taboo|Yes|Yes|
+| [oulipo.social](https://oulipo.social/)|An Oulipo Mastodon in which that fifth symbol in Latin script is taboo|Yes|No|
 | [indigo.zone](https://indigo.zone)|Open Registrations, General Purpose|Yes|No|
 | [mastodon.cloud](https://mastodon.cloud)|An open Mastodon instance with people from all around the world|Yes|Yes|
 | [mst3k.interlinked.me](https://mst3k.interlinked.me)|Open registrations, general purpose|Yes|Yes|


### PR DESCRIPTION
Reverts tootsuite/documentation#21

Oulipo.social's IPv6 DOES NOT WORK : 
![screen shot 2017-04-14 at 11 11 51](https://cloud.githubusercontent.com/assets/3009327/25039327/4a399e8a-2103-11e7-8487-6beb59c65328.png) https://atlas.ripe.net/measurements/8096550/#!probes