### PR TITLE
Fix follow and unfollow api documents

### DIFF
--- a/Using-the-API/API.md
+++ b/Using-the-API/API.md
@@ -122,8 +122,8 @@ Returns an array of [Statuses](#status).
 
 #### Following/unfollowing an account:
 
-    GET /api/v1/accounts/:id/follow
-    GET /api/v1/accounts/:id/unfollow
+    POST /api/v1/accounts/:id/follow
+    POST /api/v1/accounts/:id/unfollow
 
 Returns the target [Account](#account).
 

--- a/Using-the-API/API.md
+++ b/Using-the-API/API.md
@@ -125,7 +125,7 @@ Returns an array of [Statuses](#status).
     POST /api/v1/accounts/:id/follow
     POST /api/v1/accounts/:id/unfollow
 
-Returns the target [Account](#account).
+Returns the target [Relationship](#relationship).
 
 #### Blocking/unblocking an account:
 


### PR DESCRIPTION
The follow and unfollow methods are POST, not GET.

```console
$ RAILS_ENV=production rails routes
...
             follow_api_v1_account POST   /api/v1/accounts/:id/follow(.:format)                api/v1/accounts#follow
           unfollow_api_v1_account POST   /api/v1/accounts/:id/unfollow(.:format)              api/v1/accounts#unfollow
```

Also, the returned JSON is below.

```
{id: 1, following: true, followed_by: true, blocking: false, muting: false, requested: false}
{id: 1, following: false, followed_by: true, blocking: false, muting: false, requested: false}
```

This is a Relationship.