### PR TITLE
Fix account entities

### DIFF
--- a/Using-the-API/API.md
+++ b/Using-the-API/API.md
@@ -409,7 +409,9 @@ ___
 | `note`                   | Biography of user |
 | `url`                    | URL of the user's profile page (can be remote) |
 | `avatar`                 | URL to the avatar image |
+| `avatar_static`          | URL to the avatar static image (gif) |
 | `header`                 | URL to the header image |
+| `header_static`          | URL to the header static image (gif) |
 
 ### Application
 

--- a/Using-the-API/API.md
+++ b/Using-the-API/API.md
@@ -401,15 +401,15 @@ ___
 | `username`               | The username of the account |
 | `acct`                   | Equals `username` for local users, includes `@domain` for remote ones |
 | `display_name`           | The account's display name |
-| `note`                   | Biography of user |
-| `url`                    | URL of the user's profile page (can be remote) |
-| `avatar`                 | URL to the avatar image |
-| `header`                 | URL to the header image |
 | `locked`                 | Boolean for when the account cannot be followed without waiting for approval first |
 | `created_at`             | The time the account was created |
 | `followers_count`        | The number of followers for the account |
 | `following_count`        | The number of accounts the given account is following |
 | `statuses_count`         | The number of statuses the account has made |
+| `note`                   | Biography of user |
+| `url`                    | URL of the user's profile page (can be remote) |
+| `avatar`                 | URL to the avatar image |
+| `header`                 | URL to the header image |
 
 ### Application
 


### PR DESCRIPTION
## 1. Fix order to account entities

When I got, the order of account entities was below.

```console
$ curl -H 'Authorization:Bearer xxxTOKENxxx' https://example.com/api/v1/accounts/1

{
  "id": 1,
  "username": "foo",
  "acct": "foo",
  "display_name": "bar",
  "locked": false,
  "created_at": "2017-04-14T12:38:26.726Z",
  "followers_count": 123,
  "following_count": 456,
  "statuses_count": 789,
  "note": "Hello, World!",
  "url": "https://example.com/@foo",
  "avatar": "https://img.example.com/accounts/avatars/000/000/186/original/55a4b1361703b60b.png?1492173581",
  "avatar_static": "https://img.example.com/accounts/avatars/000/000/186/original/55a4b1361703b60b.png?1492173581",
  "header": "/headers/original/missing.png",
  "header_static": "/headers/original/missing.png"
}
```

So I fixed the order.

## 2. Add static image to account entities

The account provides a static image of the gif image.

[app/models/account.rb#L165](https://github.com/tootsuite/mastodon/blob/12f72e1740cd91929419c82c6b782393e306994c/app/models/account.rb#L165)

```ruby
  def avatar_static_url
    avatar_content_type == 'image/gif' ? avatar.url(:static) : avatar_original_url
  end

...

  def header_static_url
    header_content_type == 'image/gif' ? header.url(:static) : header_original_url
  end
```