### PR TITLE
Adding of Bonn.social

### DIFF
--- a/Using-Mastodon/List-of-Mastodon-instances.md
+++ b/Using-Mastodon/List-of-Mastodon-instances.md
@@ -78,5 +78,7 @@ There is also a list at [instances.mastodon.xyz](https://instances.mastodon.xyz)
 | [indigo.zone](https://indigo.zone)|Open Registrations, General Purpose|Yes|No|
 | [mastodon.cloud](https://mastodon.cloud)|An open Mastodon instance with people from all around the world|Yes|Yes|
 | [mst3k.interlinked.me](https://mst3k.interlinked.me)|Open registrations, general purpose|Yes|Yes|
+| [Bonn.social](https://bonn.social)|Local topics from the federal city of Bonn, Germany|Yes|No|
+
 
 We are no longer maintaining this list as instances are popping up too quickly for using GitHub to be a tenable system for tracking them. Please standby while we work on another solution


### PR DESCRIPTION
Bonn.social is a mastodon-server from Bonn, Germany