### PR TITLE
Fix follow_requests api path interface

### DIFF
--- a/Using-the-API/API.md
+++ b/Using-the-API/API.md
@@ -211,12 +211,8 @@ Returns an array of [Accounts](#account) which have requested to follow the auth
 
 #### Authorizing or rejecting follow requests:
 
-    POST /api/v1/follow_requests/authorize
-    POST /api/v1/follow_requests/reject
-
-Form data:
-
-- `id`: The id of the account to authorize or reject
+    POST /api/v1/follow_requests/:id/authorize
+    POST /api/v1/follow_requests/:id/reject
 
 Returns an empty object.
 

--- a/Using-the-API/API.md
+++ b/Using-the-API/API.md
@@ -214,6 +214,10 @@ Returns an array of [Accounts](#account) which have requested to follow the auth
     POST /api/v1/follow_requests/:id/authorize
     POST /api/v1/follow_requests/:id/reject
 
+Form data:
+
+- `id`: The id of the account to authorize or reject
+
 Returns an empty object.
 
 ### Follows


### PR DESCRIPTION
The URL interface of follow_requests was incorrect.
It is correctly the interface including the ID.

```console
$ RAILS_ENV=production rails routes
...
   authorize_api_v1_follow_request POST   /api/v1/follow_requests/:id/authorize(.:format)      api/v1/follow_requests#authorize
      reject_api_v1_follow_request POST   /api/v1/follow_requests/:id/reject(.:format)         api/v1/follow_requests#reject

```