### PR TITLE
Fix follow requests API description

### DIFF
--- a/Using-the-API/API.md
+++ b/Using-the-API/API.md
@@ -215,7 +215,7 @@ Returns an array of [Accounts](#account) which have requested to follow the auth
     POST /api/v1/follow_requests/:id/authorize
     POST /api/v1/follow_requests/:id/reject
 
-Form data:
+Parameters:
 
 - `id`: The id of the account to authorize or reject
 


### PR DESCRIPTION
`id` is a Parameters, not Form data.