### PR TITLE
Adding Mastodon Lang Remover

### DIFF
--- a/Using-Mastodon/Apps.md
+++ b/Using-Mastodon/Apps.md
@@ -19,6 +19,7 @@ Some people have started working on apps for the Mastodon API. Here is a list of
 | [Capella](https://github.com/coolstar/Capella) | Windows 7, 8.1, 10 | https://coolstar.org/capella | [@coolstar@mastodon.social](https://mastodon.social/users/coolstar)|
 |[Mastodon UWP (beta)](https://github.com/woachk/mastodon/releases)|Windows 10|<https://github.com/woachk/mastodon>|[@my123@mastodon.social](https://mastodon.social/users/my123)|
 |[mastodon.el](https://github.com/jdenen/mastodon.el)|Emacs|<https://github.com/jdenen/mastodon.el>|[@johnson@mastodon.social](https://mastodon.social/users/johnson)|
+|[Mastodon Lang Remover](https://github.com/arthurlacoste/mastodon-lang-remover)|browser|<https://github.com/arthurlacoste/mastodon-lang-remover>|[@arthak@mastodon.social](https://mastodon.social/users/arthak)|
 
 ## Bridges from/to other platforms
 


### PR DESCRIPTION
Mastodon Lang Remover is a Tampermonkey script, detecting langage and remove toots using lang specified.