### PR TITLE
Fix bad quote char in IAM policy

### DIFF
--- a/Running-Mastodon/Heroku-guide.md
+++ b/Running-Mastodon/Heroku-guide.md
@@ -77,7 +77,7 @@ To protect the privacy of the users of the your instance, you should have permis
                     "s3:*"
                 ],
                 "Resource": [
-                    "arn:aws:s3:::hentailoan”,
+                    "arn:aws:s3:::hentailoan",
                     "arn:aws:s3:::hentailoan/*"
                 ]
             }


### PR DESCRIPTION
Just a small tweak to fix the sample IAM policy in the docs.