### PR TITLE
Adds note about persisting volumes.

### DIFF
--- a/Running-Mastodon/Docker-Guide.md
+++ b/Running-Mastodon/Docker-Guide.md
@@ -6,8 +6,7 @@ The project now includes a `Dockerfile` and a `docker-compose.yml` file (which r
 
 ## Setting up
 
-Review the settings in `docker-compose.yml`. Note that it is not default to store the postgresql database and redis databases in a persistent storage location,
-so you may need or want to adjust the settings there.
+Review the settings in `docker-compose.yml`. Note that it is **not default** to store the postgresql database and redis databases in a persistent storage location. If you plan on running your instance in production, you **must** uncomment the [`volumes` directive](https://github.com/tootsuite/mastodon/blob/972f6bc861affd9bc40181492833108f905a04b6/docker-compose.yml#L7-L16) in `docker-compose.yml`.
 
 Then, you need to fill in the `.env.production` file:
 


### PR DESCRIPTION
This seems to have caught some folks, but by default the `docker-compose.yml` specifies no persistence for databases. This PR draws attention to that fact.

Fixes https://github.com/tootsuite/mastodon/issues/1376 . Fixes https://github.com/tootsuite/mastodon/issues/1475 .