### PR TITLE
update nginx ssl config

### DIFF
--- a/Running-Mastodon/Production-guide.md
+++ b/Running-Mastodon/Production-guide.md
@@ -40,6 +40,7 @@ server {
 
   ssl_certificate     /etc/letsencrypt/live/example.com/fullchain.pem;
   ssl_certificate_key /etc/letsencrypt/live/example.com/privkey.pem;
+  ssl_dhparam         /etc/ssl/certs/dhparam.pem;
 
   keepalive_timeout    70;
   sendfile             on;


### PR DESCRIPTION
To further increase security add a strong Diffie-Hellman group, which is standard practice when setting up ssl certs. Anyone who can setup letsencrypt can also setup a DH group.