### PR TITLE
Add default CSP

### DIFF
--- a/Running-Mastodon/Production-guide.md
+++ b/Running-Mastodon/Production-guide.md
@@ -12,7 +12,9 @@ The following HTTP headers are already set internally and should not be set agai
 
 ## Nginx
 
-Regardless of whether you go with the Docker approach or not, here is an example Nginx server configuration:
+Regardless of whether you go with the Docker approach or not, here is an example Nginx server configuration.
+
+At a minimum, you'll want to replace any occurrence of `example.com` with your actual hostname, and `/home/mastodon/live/public` with the location of your actual mastodon `public/` directory.
 
 ```nginx
 map $http_upgrade $connection_upgrade {
@@ -58,6 +60,8 @@ server {
   gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
 
   add_header Strict-Transport-Security "max-age=31536000";
+  add_header Content-Security-Policy "default-src 'none'; style-src 'self' 'unsafe-inline'; script-src 'self'; img-src 'self' data:; media-src 'self' data:; connect-src 'self' wss://example.com; font-src 'self'; frame-ancestors 'none'; manifest-src 'self';";
+  add_header Referrer-Policy "strict-origin-when-cross-origin";
 
   location / {
     try_files $uri @proxy;


### PR DESCRIPTION
# What?
Add a default CSP that allows anything from the local domain, plus inline styles, data: URIs, and no framing. Plus, a referrer policy that will send a full Referer header to the local origin (thus, not mess with stats etc.), but truncate to strict origin when browsing across origins.

# Why?
Including reasonable defaults here for both security and privacy will do the fediverse much good.

I am open to suggestions on what would be a better default. For instance, unsafe-inline for styles bugs me a little but if not, we are breaking emoji as currently implemented, for instance. Similar reasoning goes for data URIs.

Also note that this CSP won't work like this with multi-server / CDN deployments, but I reckon a person who can set up a CDN can figure out how to tweak the CSP.

