### PR TITLE
Add nginx config for static assets

### DIFF
--- a/Running-Mastodon/Production-guide.md
+++ b/Running-Mastodon/Production-guide.md
@@ -64,8 +64,6 @@ server {
   }
 
   location /assets {
-    # Serve static, checksummed assets directly from nginx as a perf boost
-    root /home/mastodon/live/public;
     add_header Cache-Control "public, max-age=31536000, immutable";
   }
 

--- a/Running-Mastodon/Production-guide.md
+++ b/Running-Mastodon/Production-guide.md
@@ -63,6 +63,12 @@ server {
     try_files $uri @proxy;
   }
 
+  location /assets {
+    # Serve static, checksummed assets directly from nginx as a perf boost
+    root /home/mastodon/live/public;
+    add_header Cache-Control "public, max-age=31536000, immutable";
+  }
+
   location @proxy {
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
AFAICT there's no reason not to serve static assets directly from nginx, so this seems like a reasonable recommendation for the official docs.

I also added a high enough cache time and `cache-control:immutable` because all these resources have their checksums in the names, so they can essentially be cached indefinitely. `cache-control:immutable` is in Firefox 49+ and Edge 15 and causes the browser to skip an unnecessary revalidation request even when hitting reload/F5 ([details here](https://hacks.mozilla.org/2017/01/using-immutable-caching-to-speed-up-the-web/)). Chrome doesn't have this but it has a heuristic, and I confirmed that 31536000 (365 days) matches the heuristic so it avoids the revalidation as well.