### PR TITLE
Add to FAQ.md the questions asked by users in the Fediverse

### DIFF
--- a/Using-Mastodon/FAQ.md
+++ b/Using-Mastodon/FAQ.md
@@ -42,3 +42,131 @@ Because Mastodon has been created from a blank slate, it is much simpler to have
 Development of Mastodon and hosting of mastodon.social is funded through my [Patreon (also BTC/PayPal donations)](https://www.patreon.com/user?u=619786). Beyond that, I am not interested in VC funding, monetizing, advertising, or anything of that sort. I could offer setup/maintenance services on demand.
 
 The software is free and open source and communities should host their own servers if they can, that way the costs are more or less distributed. Obviously it'd be hard for me to pay the bills if literally everyone decided to use the mastodon.social instance only.
+
+#### What’s a “federation”?
+It’s a group of mastodon servers that share toots with each other.
+
+#### What’s an “instance”?
+It’s a server that you can have an account on. Each has its own policies, because they can be run by anyone!
+
+#### How many people signed up for Mastodon? Can I see a chart of user counts over time?
+Sure, you can follow [@mastodonusercount@social.lou.lt](https://social.lou.lt/@mastodonusercount).
+
+#### How do you really spell “mast–don”?
+It’s **mastodon** with two Os. You will get it wrong at least once.
+
+#### How do I get this on Android?
+Try [Tusky](https://play.google.com/store/apps/details?id=com.keylesspalace.tusky).
+
+#### On Android, I really want multiple account support.
+Try [TootyFruity](https://play.google.com/store/apps/details?id=ch.kevinegli.tootyfruity221258).
+
+#### How do I get this on iPhone?
+Try [Amaroq](https://itunes.apple.com/us/app/amaroq-for-mastodon/id1214116200). Also, Safari might be a choice.
+
+#### Can Tusky do ‘💇’? How about feature “🔥”? And what’s with Tusky’s “⛱”?
+You can follow or contact Tusky at [@Tusky@mastodon.social](https://mastodon.social/@Tusky), or the developers [@Vavassor@mastodon.social](https://mastodon.social/@Vavassor) and [@daycode@mastodon.social](https://mastodon.social/@daycode)
+
+#### How do I search?
+You can search for people and hashtags, but not general text. Use the box above the tooting area.
+
+![Search Box](https://octodon.social/media/fytp1Gxgo13W-Gtx0LM)
+
+#### How do I DM (Direct Message)?"
+Click on the **globe** beneath your toot for privacy options, including DM.
+
+#### I don’t get the local vs. federated timeline thing.
+“Local” toots are from the server you signed up at. “Federated” are the all the toots your server knows about. (It's complicated, but short version is: “toots from people that you and other locals follow.”)
+
+#### What’s trending?
+Follow the esteemed [@TrendingBot@mastodon.social](https://mastodon.social/@TrendingBot).
+
+#### What’s “CW”?
+“CW” stands for “Content Warning.” You can use it to hide your toot, like a spoiler.
+
+#### What’s with the pineapples?
+They’re tasty, and they make people smile. Just go with it.
+
+#### How do I delete my account?
+At the moment, you will have to toot the admin of your instance for help on that one.
+
+#### Who is my admin, and how do I contact/follow them?
+Click on **Getting Started**, then **Extended Information**. An info page displays. Hopefully, they put their contact information in there!
+
+![Getting Started](https://octodon.social/media/TKlZpSNRRcHBOEFNlGs) ![Extended Information](https://octodon.social/media/D7bfl1NYzNy4XIT8nLs) ![Info Page](https://octodon.social/media/zvoI8yUt4uurZcKqFRk)
+
+#### Wow, I keep seeing offensive stuff from a particular instance, is there a way to block *all* of it?
+Not without a lot of clicking, sorry. But, your instance admin can do it! Please contact her.
+
+#### How do I get verified with a “✅”?
+“✅” is an emoji, *only* for lulz. There is no verification on Mastodon. You can copy and paste “✅” into your bio if you wish, you cheeky monkey.
+
+#### Can I edit a toot?
+No, sorry. But you could delete and rewrite...
+
+#### How do I view my favorite toots?
+Click "Getting Started," then "Favourites."
+
+![img](http://octodon.social/media/KKVbLbEdqa22oNNKQYg "Getting Started") ![img](https://octodon.social/media/wYG2bD7bAAplgZKkwH8 "Favourites")
+
+#### Can I quote a toot?
+Not currently. You must manually copy and paste the text to quote it.
+
+#### If my instance shuts down forever, do I lose my data?
+Yes you do.
+
+#### Can I save my data?
+Yes, some of it! It‘s under **Preferences->Data export**
+
+![Data Export](https://octodon.social/media/Qkn_ELLQqCjZhWI5NQo)
+
+#### I can’t see toots of a remote user under their bio!
+Click their avatar pic. This will take you directly to their instance, which displays all their public toots.
+
+#### How do I see threads?
+Click the toot body for **Expanded View**. This will show threads the toot’s connected to.
+
+#### How do I link to toots?
+Click the toot body for a **Expanded View**. Right-click on the **date beneath** the toot for a permalink.
+
+#### How do I link to my bio?
+In Firefox, right-click on your avatar picture. Select **Copy link location**.
+
+![URL Bio](https://octodon.social/media/1K7gKcZIY1D_tYnwvj0)
+
+#### Does clicking a #hashtag show  local results, or federated?
+Federated.
+
+#### When I mute a boost, who gets muted, the booster or the original author?
+The original author.
+
+#### Can I preview the people on an instance, and what they’re saying?
+Yes, try the excellent [instance preview tool](http://www.unmung.com/mastoview?url=mastodon.social&amp;amp;view=local).
+	
+#### How do I hide the toots of languages I don’t understand?
+The developers are working on this and other filtering options, stay tuned!
+
+#### Is automatic translation supported?
+Not yet, but there is a [Firefox TamperMonkey script](https://github.com/tomouchuu/mastodon-translate) that might work for you.
+	
+#### Do toots automatically broadcast federated, or stay local?
+By default, toots are federated (public), and will show on both timelines. You can change the default behavior through **Settings->Preferences->Post Privacy.**
+
+![Settings](https://octodon.social/media/kQB46sQCKN654Q-DOCY) ![Preferences](https://octodon.social/media/gtUtLEA_li6UlaqzOh8)![Post Privacy](https://octodon.social/media/f0euT4bv0Es5h-gMbg8)
+
+#### I found a bug or have a suggestion for Mastodon.
+You can file a bug or submit suggestions at [Mastodon’s Issue Tracker.](https://github.com/tootsuite/mastodon/issues) 
+
+#### Hey I love mastodon FAQs! Can I have more?
+Here’s more, from hardworking individuals trying to help, too.
+
+* [https://hastebin.com/raw/xuqogukimu](https://hastebin.com/raw/xuqogukimu)
+
+* [https://github.com/ThomasLeister/masto-faq](https://github.com/ThomasLeister/masto-faq)
+
+* [http://mastoguide.info/Pages/FAQindex.html](http://mastoguide.info/Pages/FAQindex.html)
+
+* [https://medium.com/tebelorg/my-first-10-days-on-mastodon-fediverse-f6f1d73db8d7](https://medium.com/tebelorg/my-first-10-days-on-mastodon-fediverse-f6f1d73db8d7)
+
+* [https://github.com/tootsuite/documentation/blob/master/Using-Mastodon/FAQ.md](https://github.com/tootsuite/documentation/blob/master/Using-Mastodon/FAQ.md)
+

--- a/Using-Mastodon/FAQ.md
+++ b/Using-Mastodon/FAQ.md
@@ -141,7 +141,7 @@ Federated.
 The original author.
 
 #### Can I preview the people on an instance, and what they’re saying?
-Yes, try the excellent [instance preview tool](http://www.unmung.com/mastoview?url=mastodon.social&amp;amp;view=local).
+Yes, try the excellent [instance preview tool](http://www.unmung.com/mastoview?url=mastodon.social&view=local).
 	
 #### How do I hide the toots of languages I don’t understand?
 The developers are working on this and other filtering options, stay tuned!
@@ -169,4 +169,3 @@ Here’s more, from hardworking individuals trying to help, too.
 * [https://medium.com/tebelorg/my-first-10-days-on-mastodon-fediverse-f6f1d73db8d7](https://medium.com/tebelorg/my-first-10-days-on-mastodon-fediverse-f6f1d73db8d7)
 
 * [https://github.com/tootsuite/documentation/blob/master/Using-Mastodon/FAQ.md](https://github.com/tootsuite/documentation/blob/master/Using-Mastodon/FAQ.md)
-


### PR DESCRIPTION
An append to the FAQ.md containing actual questions asked in the fediverse. I have more from @raccoon@awoo.space (https://hastebin.com/raw/xuqogukimu), but I'm waiting for a recent version. Also, the images are remote (served by octodon.social), and probably should be moved to the repo if accepted.