### PR TITLE
Add documentation for /api/v1/notifications/dismiss

### DIFF
--- a/Using-the-API/API.md
+++ b/Using-the-API/API.md
@@ -292,6 +292,13 @@ Returns the [Notification](#notification).
 Deletes all notifications from the Mastodon server for the authenticated user.
 Returns an empty object.
 
+#### Dismissing a single notification:
+
+    POST /api/v1/notifications/dismiss/:id
+
+Deletes the notification from the Mastodon server for the authenticated user.
+Returns an empty object.
+
 ### Reports
 
 #### Fetching a user's reports:


### PR DESCRIPTION
Adds documentation for the API that was added in https://github.com/tootsuite/mastodon/pull/2251.