### PR TITLE
Mark all APIs that do not require authentication

### DIFF
--- a/Using-the-API/API.md
+++ b/Using-the-API/API.md
@@ -289,6 +289,7 @@ Returns the local representation of the followed account, as an [Account](#accou
     GET /api/v1/instance
 
 Returns the current [Instance](#instance).
+
 Does not require authentication.
 
 ### Media
@@ -383,6 +384,8 @@ Returns [Results](#results).
 If `q` is a URL, Mastodon will attempt to fetch the provided account or status.
 Otherwise, it will do a local account and hashtag search.
 
+Does not require authentication.
+
 ### Statuses
 
 #### Fetching a status:
@@ -391,17 +394,23 @@ Otherwise, it will do a local account and hashtag search.
 
 Returns a [Status](#status).
 
+Does not require authentication.
+
 #### Getting status context:
 
     GET /api/v1/statuses/:id/context
 
 Returns a [Context](#context).
 
+Does not require authentication.
+
 #### Getting a card associated with a status:
 
     GET /api/v1/statuses/:id/card
 
 Returns a [Card](#card).
+
+Does not require authentication.
 
 #### Getting who reblogged/favourited a status:
 
@@ -417,6 +426,8 @@ Query parameters:
 `max_id` and `since_id` are usually get from the `Link` header.
 
 Returns an array of [Accounts](#account).
+
+Does not require authentication.
 
 #### Posting a new status:
 
@@ -471,6 +482,8 @@ Query parameters:
 `max_id` and `since_id` are usually get from the `Link` header.
 
 Returns an array of [Statuses](#status), most recent ones first.
+
+'public' and 'tag' timelines do not require authentication.
 ___
 
 ## Entities


### PR DESCRIPTION
This is a clarification for tootsuite/mastodon#2273
I have passed on all APIs with curl to find those that do not require authentication with a token.