### PR TITLE
Add yarn install option

### DIFF
--- a/Running-Mastodon/Development-guide.md
+++ b/Running-Mastodon/Development-guide.md
@@ -17,7 +17,7 @@ The command to install Ruby project dependencies does not require any flags, i.e
 
 Similarly, installing JavaScript dependencies doesn't require any flags:
 
-    yarn install
+    yarn install --pure-lockfile
 
 By default the development environment wants to connect to a `mastodon_development` database on localhost using your user/ident to login to Postgres (i.e. not a md5 password)
 

--- a/Running-Mastodon/Production-guide.md
+++ b/Running-Mastodon/Production-guide.md
@@ -175,7 +175,7 @@ Then you can proceed to install project dependencies:
 
     gem install bundler
     bundle install --deployment --without development test
-    yarn install
+    yarn install --pure-lockfile
 
 ## Configuration
 
@@ -298,7 +298,7 @@ As part of your deploy, you may need to run:
 
 if anything in the `/db/` directory has changed, and/or
 
-- `yarn install`
+- `yarn install --pure-lockfile`
 - `RAILS_ENV=production bundle exec rails assets:precompile`
 
 if anything in the `/app/assets` directory changed.


### PR DESCRIPTION
Without the `--pure-lockfile` option, the `yarn.lock` file will be updated.