### PR TITLE
Adds note about running off master.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@
 - [Push notifications](Using-the-API/Push-notifications.md)
 
 ### [Running Mastodon](Running-Mastodon)
+
+**Please note**: It is highly recommended to run a [tagged release](https://github.com/tootsuite/mastodon/releases) of Mastodon and **not** run off the current `master` branch.
+
 - [Resources needed](Running-Mastodon/Resources-needed.md)
 - [Production guide](Running-Mastodon/Production-guide.md)
 - [Docker guide](Running-Mastodon/Docker-Guide.md)


### PR DESCRIPTION
There's not a great place to put this, since documentation for various deployment strategies is so disperse and various, so I put it here. It's important, and would help a lot with GitHub issues and user-facing bugs.