### PR TITLE
Include explicit production environment

### DIFF
--- a/Running-Mastodon/Maintenance-Tasks.md
+++ b/Running-Mastodon/Maintenance-Tasks.md
@@ -7,3 +7,5 @@ These tasks are available to instance operators:
 - `rake mastodon:push:refresh` re-subscribes PuSH for expiring remote users, this should be run periodically from a cronjob and quite often as the expiration time depends on the particular hub of the remote user
 - `rake mastodon:feeds:clear_all` removes all timelines, which forces them to be re-built on the fly next time a user tries to fetch their home/mentions timeline. Only for troubleshooting
 - `rake mastodon:feeds:clear` removes timelines of users who haven't signed in lately, which allows to save RAM and improve message distribution. This is required to be run periodically so that when they login again the regeneration process will trigger
+
+If you receive an error, such as `WARNING: Sidekiq testing API enabled, but this is not the test environment.  Your jobs will not go to Redis.`, try adding `RAILS_ENV=production ` to the beginning of each task.


### PR DESCRIPTION
These tasks sometimes fail under non-Docker installations when the administrator tries to run them without explicitly requesting the production environment.