### PR TITLE
Fix some issues with the PgBouncer-guide.md

### DIFF
--- a/Running-Mastodon/PgBouncer-guide.md
+++ b/Running-Mastodon/PgBouncer-guide.md
@@ -50,14 +50,27 @@ PgBouncer has two config files: `pgbouncer.ini` and `userlist.txt` both in `/etc
 
 #### Configuring userlist.txt
 
-Add the `mastodon` user to the `userlist.txt`:
+Add the `mastodon` user to the `userlist.txt` using md5 or plain text:
 
     "mastodon" "pineapple"
+
+Or using md5:
+
+    "mastodon" "md5bc8a988ff49c4d1d8c43c4747c68fc0b"
+
+The md5 password is just the md5sum of `password+username` with the string `md5` prepended. For instance, to derive the hash for user mastodon with pineapple password, you can do:
+
+    # ubuntu, debian, etc.
+    echo -n "pineapplemastodon" | md5sum
+    # macOS, openBSD, etc.
+    md5 -s "pineapplemastodon"
+
+You will get this as the result `bc8a988ff49c4d1d8c43c4747c68fc0b` and you prepend the string `md5`, resulting in `md5bc8a988ff49c4d1d8c43c4747c68fc0b`.
 
 You'll also want to create a `pgbouncer` admin user to log in to the PgBouncer admin database. So here's a sample `userlist.txt`:
 
 ```
-"mastodon" "pineapple"
+"mastodon" "md5bc8a988ff49c4d1d8c43c4747c68fc0b"
 "pgbouncer" "p4ssw0rd"
 ```
 
@@ -78,7 +91,7 @@ listen_addr = 127.0.0.1
 listen_port = 6432
 ```
 
-Put `md5` as the `auth_type`:
+Put `md5` as the `auth_type` (auth_type md5 allows both plain text and md5 passwords):
 
 ```ini
 auth_type = md5


### PR DESCRIPTION
After using PgBouncer guide to install PgBouncer on a fresh Debian machine, I ran into some issues and had to do some changes to make it work.
On `/etc/default/pgbouncer` had to change `START` value to 1 and use plain text passwords in the `userlist.txt`.

Besides those changes to the guide, I added some details that I believe can help after first install.

Question:
When PgBouncer is installed and I do a `bundle exec rails db:migrate`, I get "WARNING:  you don't own a lock of type ExclusiveLock". [It looks like I am not the only one](https://masto.pt/@hugo/93601). Should I add a notice in the guide about this?
