### PR TITLE
Recommend HTTP/2 in the nginx config

### DIFF
--- a/Running-Mastodon/Production-guide.md
+++ b/Running-Mastodon/Production-guide.md
@@ -30,8 +30,8 @@ server {
 }
 
 server {
-  listen 443 ssl;
-  listen [::]:443 ssl;
+  listen 443 ssl http2;
+  listen [::]:443 ssl http2;
   server_name example.com;
 
   ssl_protocols TLSv1.2;


### PR DESCRIPTION
I can't think of any reason not to enable HTTP/2. It has nearly [universal support](http://caniuse.com/#feat=http2), including IE11 which Mastodon doesn't appear to support anyway due to missing an `Object.assign` polyfill. Been testing toot.cafe on H2 with Safari, Edge, Chrome, and Firefox, and everything looks A-OK. :smiley: