### PR TITLE
Add photos and avatars to static/immutable cache

### DIFF
--- a/Running-Mastodon/Production-guide.md
+++ b/Running-Mastodon/Production-guide.md
@@ -64,7 +64,7 @@ server {
     try_files $uri @proxy;
   }
 
-  location /assets {
+  location ~ ^/(assets|system/media_attachments/files|system/accounts/avatars) {
     add_header Cache-Control "public, max-age=31536000, immutable";
   }
 


### PR DESCRIPTION
The files under `system/media_attachments/files` and `system/accounts/avatars` also appear to be uniquely identified by their filename, so it should be safe to increase the cache for these. I'm running this in production right now on toot.cafe and it's working well so far.