### PR TITLE
Fix various instances of "Maximum number of"

### DIFF
--- a/Using-the-API/API.md
+++ b/Using-the-API/API.md
@@ -121,7 +121,7 @@ Query parameters:
 
 - `max_id` (optional): Get a list of followers with ID less than or equal this value
 - `since_id` (optional): Get a list of followers with ID greater than this value
-- `limit` (optional): Maximum number of accounts to get (Default 40, Max 80)
+- `limit` (optional): Maximum number of followers to get (Default 40, Max 80)
 
 `max_id` and `since_id` are usually get from the `Link` header.
 
@@ -135,7 +135,7 @@ Query parameters:
 
 - `max_id` (optional): Get a list of followings with ID less than or equal this value
 - `since_id` (optional): Get a list of followings with ID greater than this value
-- `limit` (optional): Maximum number of accounts to get (Default 40, Max 80)
+- `limit` (optional): Maximum number of followings to get (Default 40, Max 80)
 
 `max_id` and `since_id` are usually get from the `Link` header.
 
@@ -151,7 +151,7 @@ Query parameters:
 - `exclude_replies` (optional): Skip statuses that reply to other statuses
 - `max_id` (optional): Get a list of statuses with ID less than or equal this value
 - `since_id` (optional): Get a list of statuses with ID greater than this value
-- `limit` (optional): Maximum number of accounts to get (Default 20, Max 40)
+- `limit` (optional): Maximum number of statuses to get (Default 20, Max 40)
 
 `max_id` and `since_id` are usually get from the `Link` header.
 
@@ -228,7 +228,7 @@ Query parameters:
 
 - `max_id` (optional): Get a list of blocks with ID less than or equal this value
 - `since_id` (optional): Get a list of blocks with ID greater than this value
-- `limit` (optional): Maximum number of accounts to get (Default 40, Max 80)
+- `limit` (optional): Maximum number of blocks to get (Default 40, Max 80)
 
 `max_id` and `since_id` are usually get from the `Link` header.
 
@@ -244,7 +244,7 @@ Query parameters:
 
 - `max_id` (optional): Get a list of favourites with ID less than or equal this value
 - `since_id` (optional): Get a list of favourites with ID greater than this value
-- `limit` (optional): Maximum number of accounts to get (Default 20, Max 40)
+- `limit` (optional): Maximum number of favourites to get (Default 20, Max 40)
 
 `max_id` and `since_id` are usually get from the `Link` header.
 
@@ -260,7 +260,7 @@ Query parameters:
 
 - `max_id` (optional): Get a list of follow requests with ID less than or equal this value
 - `since_id` (optional): Get a list of follow requests with ID greater than this value
-- `limit` (optional): Maximum number of accounts to get (Default 40, Max 80)
+- `limit` (optional): Maximum number of requests to get (Default 40, Max 80)
 
 `max_id` and `since_id` are usually get from the `Link` header.
 
@@ -321,7 +321,7 @@ Query parameters:
 
 - `max_id` (optional): Get a list of mutes with ID less than or equal this value
 - `since_id` (optional): Get a list of mutes with ID greater than this value
-- `limit` (optional): Maximum number of accounts to get (Default 40, Max 80)
+- `limit` (optional): Maximum number of mutes to get (Default 40, Max 80)
 
 `max_id` and `since_id` are usually get from the `Link` header.
 
@@ -337,7 +337,7 @@ Query parameters:
 
 - `max_id` (optional): Get a list of notifications with ID less than or equal this value
 - `since_id` (optional): Get a list of notifications with ID greater than this value
-- `limit` (optional): Maximum number of accounts to get (Default 15, Max 30)
+- `limit` (optional): Maximum number of notifications to get (Default 15, Max 30)
 
 `max_id` and `since_id` are usually get from the `Link` header.
 
@@ -428,7 +428,7 @@ Query parameters:
 
 - `max_id` (optional): Get a list of reblogged/favourited with ID less than or equal this value
 - `since_id` (optional): Get a list of reblogged/favourited with ID greater than this value
-- `limit` (optional): Maximum number of accounts to get (Default 40, Max 80)
+- `limit` (optional): Maximum number of reblogged/favourited to get (Default 40, Max 80)
 
 `max_id` and `since_id` are usually get from the `Link` header.
 
@@ -482,9 +482,9 @@ Returns the target [Status](#status).
 Query parameters:
 
 - `local` (optional; public and tag timelines only): Only return statuses originating from this instance
-- `max_id` (optional): Get a list of timelines with ID less than or equal this value
-- `since_id` (optional): Get a list of timelines with ID greater than this value
-- `limit` (optional): Maximum number of accounts to get (Default 20, Max 40)
+- `max_id` (optional): Get a list of statuses on the requested timeline with ID less than or equal this value
+- `since_id` (optional): Get a list of statuses on the requested timeline with ID greater than this value
+- `limit` (optional): Maximum number of statuses on the requested timeline to get (Default 20, Max 40)
 
 `max_id` and `since_id` are usually get from the `Link` header.
 


### PR DESCRIPTION
The text always specified "Maximum number of accounts" instead of
naming the object that was actually being retrieved such as statuses
or blocks.