### PR TITLE
Add default CSP (take 2)

### DIFF
--- a/Running-Mastodon/Production-guide.md
+++ b/Running-Mastodon/Production-guide.md
@@ -60,7 +60,7 @@ server {
   gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
 
   add_header Strict-Transport-Security "max-age=31536000";
-  add_header Content-Security-Policy "style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; object-src 'self'; img-src data: https:; media-src data: https:; connect-src 'self' wss://example.com; upgrade-insecure-requests";
+  add_header Content-Security-Policy "style-src 'self' 'unsafe-inline'; script-src 'self'; object-src 'self'; img-src data: https:; media-src data: https:; connect-src 'self' wss://example.com; upgrade-insecure-requests";
   add_header Referrer-Policy "strict-origin-when-cross-origin";
 
   location / {

--- a/Running-Mastodon/Production-guide.md
+++ b/Running-Mastodon/Production-guide.md
@@ -61,7 +61,6 @@ server {
 
   add_header Strict-Transport-Security "max-age=31536000";
   add_header Content-Security-Policy "style-src 'self' 'unsafe-inline'; script-src 'self'; object-src 'self'; img-src data: https:; media-src data: https:; connect-src 'self' wss://example.com; upgrade-insecure-requests";
-  add_header Referrer-Policy "strict-origin-when-cross-origin";
 
   location / {
     try_files $uri @proxy;

--- a/Running-Mastodon/Production-guide.md
+++ b/Running-Mastodon/Production-guide.md
@@ -12,7 +12,9 @@ The following HTTP headers are already set internally and should not be set agai
 
 ## Nginx
 
-Regardless of whether you go with the Docker approach or not, here is an example Nginx server configuration:
+Regardless of whether you go with the Docker approach or not, here is an example Nginx server configuration.
+
+At a minimum, you'll want to replace any occurrence of `example.com` with your actual hostname, and `/home/mastodon/live/public` with the location of your actual mastodon `public/` directory.
 
 ```nginx
 map $http_upgrade $connection_upgrade {
@@ -58,6 +60,8 @@ server {
   gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
 
   add_header Strict-Transport-Security "max-age=31536000";
+  add_header Content-Security-Policy "default-src 'none'; style-src 'self' 'unsafe-inline'; script-src 'self'; img-src 'self' data:; media-src 'self' data:; connect-src 'self' wss://example.com; font-src 'self'; frame-ancestors 'none'; manifest-src 'self';";
+  add_header Referrer-Policy "strict-origin-when-cross-origin";
 
   location / {
     try_files $uri @proxy;

--- a/Running-Mastodon/Production-guide.md
+++ b/Running-Mastodon/Production-guide.md
@@ -60,7 +60,7 @@ server {
   gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
 
   add_header Strict-Transport-Security "max-age=31536000";
-  add_header Content-Security-Policy "default-src 'none'; style-src 'self' 'unsafe-inline'; script-src 'self'; img-src 'self' data:; media-src 'self' data:; connect-src 'self' wss://example.com; font-src 'self'; frame-ancestors 'none'; manifest-src 'self';";
+  add_header Content-Security-Policy "style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; object-src 'self'; img-src data: https:; media-src data: https:; connect-src 'self' wss://example.com; upgrade-insecure-requests";
   add_header Referrer-Policy "strict-origin-when-cross-origin";
 
   location / {


### PR DESCRIPTION
Follow up to https://github.com/tootsuite/documentation/pull/127, with the goal of addressing the concerns in https://github.com/tootsuite/documentation/pull/127#issuecomment-297661478.

This is what we're currently running on toot.cafe and doesn't seem to cause any issues. Scores an A- on Mozilla Observatory – AFAICT it's not possible to score A+ because removing `script-src 'unsafe-inline'` will result in a console error in Firefox.

I think it's important to at least have a default recommended CSP because a lot of instances seem to be rolling their own, which can cause compat issues, e.g. there was discussion [on Matrix](https://matrix.to/#/!VMUpuubSCTxMbZkuZa:cybre.space/$1493869579852685YXIjI:matrix.org) about mst3k federation being broken due to a bad CSP.