### PR TITLE
Remove duplicate line in Administration guide

### DIFF
--- a/Running-Mastodon/Administration-guide.md
+++ b/Running-Mastodon/Administration-guide.md
@@ -8,7 +8,6 @@ So, you have a working Mastodon instance... now what?
 The following rake task:
 
     RAILS_ENV=production bundle exec rails mastodon:make_admin USERNAME=alice
-    (or docker-compose run --rm web rails mastodon:make_admin USERNAME=alice)
 
 or, if using docker:
 


### PR DESCRIPTION
Identical line about turning user into an admin via Docker is just below