### PR TITLE
Changes on ruby arrays as parameters

### DIFF
--- a/Using-the-API/API.md
+++ b/Using-the-API/API.md
@@ -74,8 +74,7 @@ ___
 ### Parameter types
 
 When an array parameter is mentioned, the Rails convention of specifying array parameters in query strings is meant.
-For example, a ruby array like `foo = [1, 2, 3]` can be encoded in the params as `foo[]=1&foo[]=2&foo[]=3`.
-Square brackets can be indexed but can also be empty.
+For example, a ruby array like `foo = [1, 2, 3]` should be encoded in the params as `foo[]=1&foo[]=2&foo[]=3`, with empty square brackets.
 
 When a file parameter is mentioned, a form-encoded upload is expected.
 


### PR DESCRIPTION
Arrays _have_ to be passed with empty square brackets, otherwise the API returns an error.

For instance https://github.com/MastodonKit/MastodonKit/blob/master/Tests/MastodonKitTests/Resources/ReportsTests.swift#L34