### PR TITLE
Moves libraries to a separate file

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 
 ### [Using the API](Using-the-API)
 - [API documentation](Using-the-API/API.md)
+- [Libraries](Using-the-API/Libraries.md)
 - [Streaming API documentation](Using-the-API/Streaming-API.md)
 - [Testing the API with cURL](Using-the-API/Testing-with-cURL.md)
 - [OAuth details](Using-the-API/OAuth-details.md)

--- a/Using-the-API/API.md
+++ b/Using-the-API/API.md
@@ -39,33 +39,7 @@ ___
 
 ## Available libraries
 
-| Language             | Library                                                                        | Developer(s)                                                                   |
-| -------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
-| Apex (Salesforce)    | [apex-mastodon](https://github.com/tzmfreedom/apex-mastodon)                   |                                                                                |
-| C# (.NET Standard)   | [Mastodot](https://github.com/yamachu/Mastodot)                                |                                                                                |
-| C# (.NET Standard)   | [Mastonet](https://github.com/glacasa/Mastonet)                                |                                                                                |
-| C# (.NET)            | [mastodon-api-cs](https://github.com/pawotter/mastodon-api-cs)                 |                                                                                |
-| C# (.NET)            | [Mastodon.Net](https://github.com/Tlaster/Mastodon.Net)                        |                                                                                |
-| Crystal              | [mastodon.cr](https://github.com/decors/mastodon.cr)                           |                                                                                |
-| Elixir               | [hunter](https://github.com/milmazz/hunter)                                    |                                                                                |
-| Go                   | [go-mastodon](https://github.com/mattn/go-mastodon)                            |                                                                                |
-| Go                   | [madon](https://github.com/McKael/madon)                                       |                                                                                |
-| Haskell              | [hastodon](https://github.com/syucream/hastodon)                               |                                                                                |
-| Java                 | [mastodon4j](https://github.com/sys1yagi/mastodon4j)                           |                                                                                |
-| JavaScript           | [libodonjs](https://github.com/Zatnosk/libodonjs)                              |                                                                                |
-| JavaScript (Browser) | [mastodon.js](https://github.com/Kirschn/mastodon.js)                          |                                                                                |
-| JavaScript (Node.js) | [node-mastodon](https://github.com/jessicahayley/node-mastodon)                |                                                                                |
-| Perl                 | [Mastodon::Client](https://metacpan.org/pod/Mastodon::Client)                  | [@jjatria@mastodon.cloud](https://mastodon.cloud/@jjatria)                     |
-| PHP                  | [Mastodon-api-php](https://github.com/yks118/Mastodon-api-php)                 |                                                                                |
-| PHP                  | [MastodonOAuthPHP](https://github.com/TheCodingCompany/MastodonOAuthPHP)       |                                                                                |
-| PHP                  | [Phediverse Mastodon REST Client](https://github.com/phediverse/mastodon-rest) |                                                                                |
-| PHP                  | [TootoPHP](https://framagit.org/MaxKoder/TootoPHP)                             |                                                                                |
-| Python               | [Mastodon.py](https://github.com/halcy/Mastodon.py)                            |                                                                                |
-| R                    | [mastodon](https://github.com/ThomasChln/mastodon)                             |                                                                                |
-| Ruby                 | [mastodon-api](https://github.com/tootsuite/mastodon-api)                      | [@Gargron@mastodon.social](https://mastodon.social/@Gargron)                   |
-| Rust                 | [mammut](https://github.com/Aaronepower/mammut)                                | [@Aaronepower@mastodon.social](https://mastodon.social/@Aaronepower)           |
-| Scala                | [scaladon](https://github.com/schwitzerm/scaladon)                             |                                                                                |
-| Swift                | [MastodonKit](https://github.com/ornithocoder/MastodonKit)                     | [@ornithocoder@mastodon.technology](https://mastodon.technology/@ornithocoder) |
+There are several libraries to interact with the Mastodon API. The list of libraries can be found on the [Libraries page](Libraries.md).
 
 ___
 

--- a/Using-the-API/Libraries.md
+++ b/Using-the-API/Libraries.md
@@ -1,0 +1,32 @@
+List of libraries
+=================
+
+Below, a list of libraries to interact with the Mastodon API, sorted by programming language and library name.
+
+| Language             | Library                                                                        | Developer(s)                                                                   |
+| -------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| Apex (Salesforce)    | [apex-mastodon](https://github.com/tzmfreedom/apex-mastodon)                   |                                                                                |
+| C# (.NET Standard)   | [Mastodot](https://github.com/yamachu/Mastodot)                                |                                                                                |
+| C# (.NET Standard)   | [Mastonet](https://github.com/glacasa/Mastonet)                                |                                                                                |
+| C# (.NET)            | [mastodon-api-cs](https://github.com/pawotter/mastodon-api-cs)                 |                                                                                |
+| C# (.NET)            | [Mastodon.Net](https://github.com/Tlaster/Mastodon.Net)                        |                                                                                |
+| Crystal              | [mastodon.cr](https://github.com/decors/mastodon.cr)                           |                                                                                |
+| Elixir               | [hunter](https://github.com/milmazz/hunter)                                    |                                                                                |
+| Go                   | [go-mastodon](https://github.com/mattn/go-mastodon)                            |                                                                                |
+| Go                   | [madon](https://github.com/McKael/madon)                                       |                                                                                |
+| Haskell              | [hastodon](https://github.com/syucream/hastodon)                               |                                                                                |
+| Java                 | [mastodon4j](https://github.com/sys1yagi/mastodon4j)                           |                                                                                |
+| JavaScript           | [libodonjs](https://github.com/Zatnosk/libodonjs)                              |                                                                                |
+| JavaScript (Browser) | [mastodon.js](https://github.com/Kirschn/mastodon.js)                          |                                                                                |
+| JavaScript (Node.js) | [node-mastodon](https://github.com/jessicahayley/node-mastodon)                |                                                                                |
+| Perl                 | [Mastodon::Client](https://metacpan.org/pod/Mastodon::Client)                  | [@jjatria@mastodon.cloud](https://mastodon.cloud/@jjatria)                     |
+| PHP                  | [Mastodon-api-php](https://github.com/yks118/Mastodon-api-php)                 |                                                                                |
+| PHP                  | [MastodonOAuthPHP](https://github.com/TheCodingCompany/MastodonOAuthPHP)       |                                                                                |
+| PHP                  | [Phediverse Mastodon REST Client](https://github.com/phediverse/mastodon-rest) |                                                                                |
+| PHP                  | [TootoPHP](https://framagit.org/MaxKoder/TootoPHP)                             |                                                                                |
+| Python               | [Mastodon.py](https://github.com/halcy/Mastodon.py)                            |                                                                                |
+| R                    | [mastodon](https://github.com/ThomasChln/mastodon)                             |                                                                                |
+| Ruby                 | [mastodon-api](https://github.com/tootsuite/mastodon-api)                      | [@Gargron@mastodon.social](https://mastodon.social/@Gargron)                   |
+| Rust                 | [mammut](https://github.com/Aaronepower/mammut)                                | [@Aaronepower@mastodon.social](https://mastodon.social/@Aaronepower)           |
+| Scala                | [scaladon](https://github.com/schwitzerm/scaladon)                             |                                                                                |
+| Swift                | [MastodonKit](https://github.com/ornithocoder/MastodonKit)                     | [@ornithocoder@mastodon.technology](https://mastodon.technology/@ornithocoder) |


### PR DESCRIPTION
The list of libraries is getting bigger and bigger. To keep the API documentation clean and specific, I'm moving the list of libraries to its own page.