### PR TITLE
Add mastodon-glossary-bot

### DIFF
--- a/Using-Mastodon/Apps.md
+++ b/Using-Mastodon/Apps.md
@@ -44,6 +44,7 @@ Some people have started working on apps for the Mastodon API. Here is a list of
 |App|Platform|Link|Developer(s)|
 |---|--------|----|------------|
 |HackerNewsBot|CLI|<https://github.com/raymestalez/mastodon-hnbot>|[@rayalez@hackertribe.io](https://hackertribe.io/users/rayalez)|
+|mastodon-glossary-bot|CLI or Heroku|<https://github.com/michelbl/mastodon-glossary-bot>|[@Michel@mastodon.etalab.gouv.fr](https://mastodon.etalab.gouv.fr/@Michel)|
 
 
 If you have a project like this, make a PR to add it to the list!


### PR DESCRIPTION
I made mastodon-glossary-bot because I could not find an equivalent to codeforamerica/glossary-bot. It is already used at https://mastodon.etalab.gouv.fr, however it is still very experimental. Hope you find it interesting enough to join the list. Otherwise I am hungry for advise to improve it.