### PR TITLE
Add doc about `webpack-dev-server`

### DIFF
--- a/Running-Mastodon/Development-guide.md
+++ b/Running-Mastodon/Development-guide.md
@@ -29,7 +29,11 @@ You can then run Mastodon with:
 
     bundle exec rails server
 
-And open `http://localhost:3000` in your browser. Background jobs run inline (aka synchronously) in the development environment, so you don't need to run a Sidekiq process. 
+Also you need to start Webpack server for asset compilation:
+
+    bin/webpack-dev-server
+
+And open `http://localhost:3000` in your browser. Background jobs run inline (aka synchronously) in the development environment, so you don't need to run a Sidekiq process.
 
 By default, your development environment will have an admin account created for you to use - the email address will be `admin@YOURDOMAIN` (e.g. admin@localhost:3000) and the password will be `mastodonadmin`.
 


### PR DESCRIPTION
Since Webpack used from https://github.com/tootsuite/mastodon/pull/2617,
it is necessary to start `webpack-dev-server`.