### PR TITLE
Fix optionality of resolve

### DIFF
--- a/Using-the-API/API.md
+++ b/Using-the-API/API.md
@@ -399,7 +399,7 @@ Form data:
 | Field             | Description                                                         | Optional   |
 | ----------------- | ------------------------------------------------------------------- | ---------- |
 | `q`               | The search query                                                    | no         |
-| `resolve`         | Whether to resolve non-local accounts                               | no         |
+| `resolve`         | Whether to resolve non-local accounts (default: don't resolve)      | yes        |
 
 Returns [Results](#results).
 


### PR DESCRIPTION
The API works correctly when ```resolve``` is not specified. Let's fix this.