### PR TITLE
Update Development-guide.md

### DIFF
--- a/Running-Mastodon/Development-guide.md
+++ b/Running-Mastodon/Development-guide.md
@@ -17,7 +17,7 @@ The command to install Ruby project dependencies is the following:
 
     bundle install
 
-Similarly, installing JavaScript dependencies doesn't require any flags:
+Install JavaScript dependencies with this command:
 
     yarn install --pure-lockfile
 


### PR DESCRIPTION
Since the document specifies the `--pure-lockfile` flag, it seems inaccurate to say, "Similarly, installing JavaScript dependencies doesn't require any flags."

I've changed the text accordingly. I hope it's appropriate!