### PR TITLE
s/assets/packs/

### DIFF
--- a/Running-Mastodon/Production-guide.md
+++ b/Running-Mastodon/Production-guide.md
@@ -67,7 +67,7 @@ server {
     try_files $uri @proxy;
   }
 
-  location ~ ^/(assets|system/media_attachments/files|system/accounts/avatars) {
+  location ~ ^/(packs|system/media_attachments/files|system/accounts/avatars) {
     add_header Cache-Control "public, max-age=31536000, immutable";
     try_files $uri @proxy;
   }


### PR DESCRIPTION
`assets` are now at `packs`. Unfortunately this change will permanently cache `stats.json` and `report.html`, but these aren't super critical since they're just for debugging. I confirmed that `manifest.json` is not affected and no other non-fingerprinted assets are affected.