### PR TITLE
Add snippet in dev guide about `yarn manage:translations`

### DIFF
--- a/Running-Mastodon/Development-guide.md
+++ b/Running-Mastodon/Development-guide.md
@@ -52,6 +52,10 @@ You can check localization status with:
 
     i18n-tasks health
 
+And update localization files after adding new strings with:
+
+    yarn manage:translations
+
 You can check code quality with:
 
     rubocop


### PR DESCRIPTION
This is a useful command that I think deserves a mention in the dev guide.