### PR TITLE
Removes id parameter from documentation

### DIFF
--- a/Using-the-API/API.md
+++ b/Using-the-API/API.md
@@ -314,12 +314,6 @@ Returns an array of [Accounts](#account) which have requested to follow the auth
     POST /api/v1/follow_requests/:id/authorize
     POST /api/v1/follow_requests/:id/reject
 
-Parameters:
-
-| Field             | Description                                                         | Optional   |
-| ----------------- | ------------------------------------------------------------------- | ---------- |
-| `id`              | The id of the account to authorize or reject                        | no         |
-
 Returns an empty object.
 
 ### Follows


### PR DESCRIPTION
`id` is neither a query item (GET) nor part of the body (POST), therefore should not be in the parameter table.