### PR TITLE
Create Serving_a_different_domain.md

### DIFF
--- a/Running-Mastodon/Serving_a_different_domain.md
+++ b/Running-Mastodon/Serving_a_different_domain.md
@@ -67,7 +67,7 @@ Therefore, the easiest way to configure domain.org is to redirect `/.well-known/
 With nginx, it would be as simple as adding:
 
 ```nginx
-location /.well-known/host-meta {
+location = /.well-known/host-meta {
        return 301 https://social.example.org$request_uri;
 }
 ```


### PR DESCRIPTION
The location directive was missing the "=" operator, which is needed to indicate that an exact match on that url is required. Without it, I was getting 404 on all requests to .well-known/webfinger.