### PR TITLE
Missing RAILS_ENV=production and bundle exec

### DIFF
--- a/Running-Mastodon/Production-guide.md
+++ b/Running-Mastodon/Production-guide.md
@@ -237,7 +237,7 @@ Then you have to configure your instance:
 
 Fill in the important data, like host/port of the redis database, host/port/username/password of the postgres database, your domain name, SMTP details (e.g. from Mailgun or equivalent transactional e-mail service, many have free tiers), whether you intend to use SSL, etc. If you need to generate secrets, you can use:
 
-    rake secret
+    RAILS_ENV=production bundle exec rake secret
 
 To get a random string. If you are setting up on one single server (most likely), then `REDIS_HOST` is localhost and `DB_HOST` is `/var/run/postgresql`, `DB_USER` is `mastodon` and `DB_NAME` is `mastodon_production` while `DB_PASS` is empty because this setup will use the ident authentication method (system user "mastodon" maps to postgres user "mastodon").
 


### PR DESCRIPTION
If you're omitting RAILS_ENV and `bundle exec` you'll have:

~~~
rake aborted!                             
NameError: uninitialized constant Annotate
[…]
~~~