### PR TITLE
Add instructions for using official build of Docker.

### DIFF
--- a/Running-Mastodon/Docker-Guide.md
+++ b/Running-Mastodon/Docker-Guide.md
@@ -14,6 +14,8 @@ The project now includes a `Dockerfile` and a `docker-compose.yml` file (which r
 
 Review the settings in `docker-compose.yml`. Note that it is **not default** to store the postgresql database and redis databases in a persistent storage location. If you plan on running your instance in production, you **must** uncomment the [`volumes` directive](https://github.com/tootsuite/mastodon/blob/972f6bc861affd9bc40181492833108f905a04b6/docker-compose.yml#L7-L16) in `docker-compose.yml`.
 
+And if you want to use the official build on DockerHub instead of building by yourself, comment each `build: .` and add tag like `:v1.4.3` after `image: gargron/mastodon` in section `web`, `streaming` and `sidekiq` in `docker-compose.yml`.
+
 Then, you need to fill in the `.env.production` file:
 
     cp .env.production.sample .env.production
@@ -23,10 +25,9 @@ Do NOT change the `REDIS_*` or `DB_*` settings when running with the default doc
 
 You will need to fill in, at least: `LOCAL_DOMAIN`, `LOCAL_HTTPS`, and the `SMTP_*` settings.
 
-
 ## Building the app
 
-Before running the first time, you need to build the images:
+Before running the first time, you need to build the images *(Skip this if you want to use the official build)*:
 
     docker-compose build
 


### PR DESCRIPTION
Official image is on DockerHub and it can be used.