### PR TITLE
Remove unavailable package from General dependencies for CentOS / RHEL

### DIFF
--- a/Running-Mastodon/Production-guide.md
+++ b/Running-Mastodon/Production-guide.md
@@ -133,7 +133,7 @@ home can be changed as needed
 
 ### CentOS / RHEL
 
-    sudo yum install libxml2-devel ImageMagick libxslt-devel git curl file g++ protobuf-compiler protobuf-devel
+    sudo yum install libxml2-devel ImageMagick libxslt-devel git curl file protobuf-compiler protobuf-devel
     sudo yum -y install epel-release
     sudo rpm --import http://li.nux.ro/download/nux/RPM-GPG-KEY-nux.ro
     sudo rpm -Uvh http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-5.el7.nux.noarch.rpm


### PR DESCRIPTION
CentOS's repo does not have package named "g++", "gcc-c++" can be used instead.
On the other hand, there is no actual problem because it is installed later by `sudo yum group install "Development tools"`.
So I have just removed "g++".