### PR TITLE
don't encourage people to use base64 avatar and header image uploads

### DIFF
--- a/Using-the-API/API.md
+++ b/Using-the-API/API.md
@@ -87,12 +87,12 @@ Returns the authenticated user's [Account](#account).
 
 Form data:
 
-| Field          | Description                                                                                                                            | Optional   |
-| -------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
-| `display_name` | The name to display in the user's profile                                                                                              | yes        |
-| `note`         | A new biography for the user                                                                                                           | yes        |
-| `avatar`       | A base64 encoded image to display as the user's avatar (e.g. `data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAUoAAADrCAYAAAA...`)       | yes        |
-| `header`       | A base64 encoded image to display as the user's header image (e.g. `data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAUoAAADrCAYAAAA...`) | yes        |
+| Field          | Description                               | Optional   |
+| -------------- | ----------------------------------------- | ---------- |
+| `display_name` | The name to display in the user's profile | yes        |
+| `note`         | A new biography for the user              | yes        |
+| `avatar`       | An avatar for the user                    | yes        |
+| `header`       | A header image for the user               | yes        |
 
 #### Getting an account's followers:
 


### PR DESCRIPTION
a potential resolution to tootsuite/mastodon#3804, achieved by not
encouraging people to use upload methods without filenames

my rationale for this being the right solution is that it brings it to
parity with the media upload method, which has already proven to be
enough for library developers to understand. it should be enough that,
early in the docs, it says that 'When a file parameter is mentioned, a
form-encoded upload is expected.'

i wouldn't mind so much if the base64 upload method didn't expose such
an insidious bug, but even if it didn't, it seems reasonable to want to
encourage developers to upload all media in a consistent way