### PR TITLE
Add the first step to clone.

### DIFF
--- a/Running-Mastodon/Docker-Guide.md
+++ b/Running-Mastodon/Docker-Guide.md
@@ -12,6 +12,11 @@ The project now includes a `Dockerfile` and a `docker-compose.yml` file (which r
 
 ## Setting up
 
+Clone Mastodon's repository.
+
+    git clone git@github.com:tootsuite/mastodon.git
+    cd mastodon
+
 Review the settings in `docker-compose.yml`. Note that it is **not default** to store the postgresql database and redis databases in a persistent storage location. If you plan on running your instance in production, you **must** uncomment the [`volumes` directive](https://github.com/tootsuite/mastodon/blob/972f6bc861affd9bc40181492833108f905a04b6/docker-compose.yml#L7-L16) in `docker-compose.yml`.
 
 Then, you need to fill in the `.env.production` file:


### PR DESCRIPTION
I was reading [documentation/Docker\-Guide\.md](https://github.com/tootsuite/documentation/blob/master/Running-Mastodon/Docker-Guide.md) to run Mastodon with Docker.

I did not know which directory to execute the "Setting up" chapter.

With the following command I successfully proceeded to the next step.

```sh
git clone git@github.com:tootsuite/mastodon.git
cd mastodon
```

I started reading from the [mastodon/README\.md](https://github.com/tootsuite/mastodon/blob/master/README.md) and read the [Deployment](https://github.com/tootsuite/documentation#running-mastodon), [Docker guide](https://github.com/tootsuite/documentation/blob/master/Running-Mastodon/Docker-Guide.md), but I could not find this command anywhere.

