### PR TITLE
Adds `mastodon:media:remove_silenced` rake task

### DIFF
--- a/Running-Mastodon/Maintenance-Tasks.md
+++ b/Running-Mastodon/Maintenance-Tasks.md
@@ -3,6 +3,7 @@
 These tasks are available to instance operators:
 
 - `rake mastodon:media:clear` removes uploads that have not been attached to any status after a while, you would want to run this from a periodic cronjob
+- `rake mastodon:media:remove_silenced` remove media attachments attributed to silenced accounts.
 - `rake mastodon:push:clear` unsubscribes from PuSH notifications for remote users that have no local followers. You may not want to actually do that, to keep a fuller footprint of the fediverse or in case your users will soon re-follow
 - `rake mastodon:push:refresh` re-subscribes PuSH for expiring remote users, this should be run periodically from a cronjob and quite often as the expiration time depends on the particular hub of the remote user
 - `rake mastodon:feeds:clear_all` removes all timelines, which forces them to be re-built on the fly next time a user tries to fetch their home/mentions timeline. Only for troubleshooting


### PR DESCRIPTION
This should be included in the documentation. I wasn't sure what sort of schedule it should be run on, so I didn't add a recommendation for one. 