### PR TITLE
`rbenv install 2.4.1` requires readline-devel

### DIFF
--- a/Running-Mastodon/Production-guide.md
+++ b/Running-Mastodon/Production-guide.md
@@ -124,7 +124,7 @@ home can be changed as needed
 
 ### Ubuntu / Debian
 
-    sudo apt-get install imagemagick ffmpeg libpq-dev libxml2-dev libxslt1-dev file git curl g++ libprotobuf-dev protobuf-compiler pkg-config
+    sudo apt-get install imagemagick ffmpeg libpq-dev libxml2-dev libxslt1-dev libreadline-dev file git curl g++ libprotobuf-dev protobuf-compiler pkg-config
     curl -sL https://deb.nodesource.com/setup_6.x | sudo bash -
     sudo apt-get install nodejs
     sudo npm install -g yarn
@@ -133,7 +133,7 @@ home can be changed as needed
 
 ### CentOS / RHEL
 
-    sudo yum install libxml2-devel ImageMagick libxslt-devel git curl file protobuf-compiler protobuf-devel
+    sudo yum install libxml2-devel ImageMagick libxslt-devel readline-devel git curl file protobuf-compiler protobuf-devel
     sudo yum -y install epel-release
     sudo rpm --import http://li.nux.ro/download/nux/RPM-GPG-KEY-nux.ro
     sudo rpm -Uvh http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-5.el7.nux.noarch.rpm


### PR DESCRIPTION
Tested on Ubuntu Server 16.04.2 LTS

See: https://github.com/rbenv/ruby-build/wiki#trouble-with-irb-or-pry

> * Trouble with irb or pry
>
> Try installing readline and recompiling Ruby.
>
>     Ubuntu: apt-get install libreadline-dev
>     Fedora: yum install readline-devel