### PR TITLE
Update Development-guide.md

### DIFF
--- a/Running-Mastodon/Development-guide.md
+++ b/Running-Mastodon/Development-guide.md
@@ -110,6 +110,7 @@ These are self-contained instructions for setting up a development environment o
 ### Installation
 
 ```
+brew install libidn
 bundle install --with development
 yarn install --pure-lockfile
 gem install foreman --no-ri --no-rdoc


### PR DESCRIPTION
in order to install the ruby-idn gem we need to make sure we have libidn installed first.