### PR TITLE
Update User-guide.md

### DIFF
--- a/Using-Mastodon/User-guide.md
+++ b/Using-Mastodon/User-guide.md
@@ -197,7 +197,7 @@ Toot Privacy | Visible on Profile | Visible on Public Timeline | Federates to ot
 ------------ | ------------------ | -------------------------- | ---------------------------
 Public | Anyone incl. anonymous viewers | Yes | Yes
 Unlisted | Anyone incl. anonymous viewers | No | Yes
-Private | Followers only | No | Only remote @mentions
+Private | Followers only | No | Yes
 Direct | No | No | Only remote @mentions
 
 #### Blocking


### PR DESCRIPTION
Followers only posts do federate even without mentions.

The text description of followers-only posts isn't ideal, either, yet, but can stand as-is - however, the table is just 100% wrong right now, and ideally should not be.