### PR TITLE
API.md: fix link to named anchor

### DIFF
--- a/Using-the-API/API.md
+++ b/Using-the-API/API.md
@@ -175,7 +175,7 @@ Query parameters:
 | ----- | ----------------------------  | ---------- |
 | `id`  | Account IDs (can be an array) | no         |
 
-Returns an array of [Relationships](#relationships) of the current user to a list of given accounts.
+Returns an array of [Relationships](#relationship) of the current user to a list of given accounts.
 
 #### Searching for accounts:
 


### PR DESCRIPTION
Use #relationship instead of #relationships.