### PR TITLE
Add block to sample nginx.conf to prevent caching sw.js

### DIFF
--- a/Running-Mastodon/Production-guide.md
+++ b/Running-Mastodon/Production-guide.md
@@ -65,6 +65,10 @@ server {
     try_files $uri @proxy;
   }
 
+  location /sw.js {
+      add_header Cache-Control no-cache;
+  }
+
   location ~ ^/(packs|system/media_attachments/files|system/accounts/avatars) {
     add_header Cache-Control "public, max-age=31536000, immutable";
     try_files $uri @proxy;

--- a/Running-Mastodon/Production-guide.md
+++ b/Running-Mastodon/Production-guide.md
@@ -236,7 +236,8 @@ server {
   }
 
   location /sw.js {
-      add_header Cache-Control no-cache;
+    add_header Cache-Control no-cache;
+    add_header Pragma "no-cache";
   }
 
   location ~ ^/(emoji|packs|system/accounts/avatars|system/media_attachments/files) {


### PR DESCRIPTION
Should this be added given the 1.5.0rc1 release notes?