### PR TITLE
API clarification regarding pagination

### DIFF
--- a/Using-the-API/API.md
+++ b/Using-the-API/API.md
@@ -122,7 +122,9 @@ Query parameters:
 | `since_id` | Get a list of followings with ID greater than this value       | yes        |
 | `limit`    | Maximum number of followings to get (Default 40, Max 80)       | yes        |
 
-`max_id` and `since_id` are usually get from the `Link` header.
+`max_id` and `since_id` are usually get from the `Link` header. Note the implied pagination.
+A typical case would be to call the URL without any parameters. Use the last `id` you see as
+the `max_id` for your next request until you get an empty array.
 
 Returns an array of [Accounts](#account).
 


### PR DESCRIPTION
Explain how to use `max_id` when querying for the accounts following somebody else.

This should probably be fixed for all the requests which take `max_id` and `since_id` parameters. This merge request only fixes it for the one request I'm currently implementing in my client because I struggled to understand what "with ID greater than this value" actually means. Clearly, it didn't mean "numerically greater" but something like "after". I couldn't think of a good way of wording the text in the table so I just added an example below the table.