### PR TITLE
sw.js should be served with max-age=0

### DIFF
--- a/Running-Mastodon/Production-guide.md
+++ b/Running-Mastodon/Production-guide.md
@@ -69,6 +69,11 @@ server {
     add_header Cache-Control "public, max-age=31536000, immutable";
     try_files $uri @proxy;
   }
+  
+  location /sw.js {
+    add_header Cache-Control "public, max-age=0";
+    try_files $uri @proxy;
+  }
 
   location @proxy {
     proxy_set_header Host $host;


### PR DESCRIPTION
This is a new requirement for Mastodon v1.5+; it's mentioned here: https://github.com/tootsuite/mastodon/releases/tag/v1.5.0rc1