### PR TITLE
Add emoji files for nginx cache rules.

### DIFF
--- a/Running-Mastodon/Production-guide.md
+++ b/Running-Mastodon/Production-guide.md
@@ -235,7 +235,7 @@ server {
     try_files $uri @proxy;
   }
 
-  location ~ ^/(packs|system/media_attachments/files|system/accounts/avatars) {
+  location ~ ^/(emoji|packs|system/accounts/avatars|system/media_attachments/files) {
     add_header Cache-Control "public, max-age=31536000, immutable";
     try_files $uri @proxy;
   }


### PR DESCRIPTION
Some cases such as nginx uses reverse proxy, emoji will return 502 if not set.
+  sort by A-z.