### PR TITLE
Don't include RCs when checking out latest tag.

### DIFF
--- a/Running-Mastodon/Updating-Mastodon-Guide.md
+++ b/Running-Mastodon/Updating-Mastodon-Guide.md
@@ -19,7 +19,7 @@ This is how you do that:
 su - mastodon
 cd ~/live
 git pull
-git checkout $(git tag -l | sort -V | tail -n 1)
+git checkout $(git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1)
 ```
 
 The above commands will update your copy of your git repository to the latest available


### PR DESCRIPTION
``git tag -l | sort -V | head -1`` will consider release candidates as the latest version, even if there's a stable release, due to how `sort -V` orders strings. Adding ``grep -v 'rc[0-9]*$'`` to filter out the release candidate tags fixes this.