### PR TITLE
Added Mastoshare

### DIFF
--- a/Using-Mastodon/Apps.md
+++ b/Using-Mastodon/Apps.md
@@ -113,6 +113,7 @@ Some people have started working on apps for the Mastodon API. Here is a list of
 |[Contest-draw](http://mastodon.tools/contest-draw/)|Web browser|<https://github.com/DavidLibeau/mastodon-tools/tree/master/contest-draw>|[@David@mastodon.xyz](https://mastodon.xyz/@David)|
 |[wall](http://mastodon.tools/wall/)|Web browser|<https://github.com/DavidLibeau/mastodon-tools/tree/master/wall>|[@David@mastodon.xyz](https://mastodon.xyz/@David)|
 [Scheduler](http://mastodon.tools/scheduler/) (beta)|Web browser|<https://github.com/DavidLibeau/mastodon-scheduler>|[@David@mastodon.xyz](https://mastodon.xyz/@David)|
+|[Mastoshare](https://github.com/koyuawsmbrtn/mastoshare)|Web browser|<https://github.com/koyuawsmbrtn/mastoshare>|[@me@koyuston.tk](https://koyuston.tk/@me)|
 
 
 If you have a project like this, make a PR to add it to the list!


### PR DESCRIPTION
I added my own small project for Mastodon. A sharing plugin for Mastodon, which you can install on your own server. I'd like to see some servers set up, so I can link them to my projects' repository.