### PR TITLE
Added Mastodon Wordpress API

### DIFF
--- a/Using-the-API/Libraries.md
+++ b/Using-the-API/Libraries.md
@@ -25,7 +25,8 @@ Below, a list of libraries to interact with the Mastodon API, sorted by programm
 | PHP                  | [Mastodon-api-php](https://github.com/yks118/Mastodon-api-php)                 |                                                                                |
 | PHP                  | [MastodonOAuthPHP](https://github.com/TheCodingCompany/MastodonOAuthPHP)       |                                                                                |
 | PHP                  | [Phediverse Mastodon REST Client](https://github.com/phediverse/mastodon-rest) |                                                                                |
-| PHP                  | [TootoPHP](https://framagit.org/MaxKoder/TootoPHP)                             |                                                                                |
+| PHP                  | [TootoPHP](https://framagit.org/MaxKoder/TootoPHP)                             |                                                                               |
+| Wordpress            | [Mastodon Wordpress API](https://github.com/L1am0/mastodon_wordpress_api)      |                                                                                |
 | Python               | [Mastodon.py](https://github.com/halcy/Mastodon.py)                            | [@halcy@icosahedron.website](https://icosahedron.website/@halcy)               |
 | R                    | [mastodon](https://github.com/ThomasChln/mastodon)                             |                                                                                |
 | Ruby                 | [mastodon-api](https://github.com/tootsuite/mastodon-api)                      | [@Gargron@mastodon.social](https://mastodon.social/@Gargron)                   |


### PR DESCRIPTION
Mastodon PHP API adapted to Wordpress HTTP API. (Replaced CURL with native commands)

This libary is licensed under the GPLv2. For concern of the original license the MIT licensefile is included, but is not applied to this project!