### PR TITLE
Update to the git checkout command.

### DIFF
--- a/Running-Mastodon/Production-guide.md
+++ b/Running-Mastodon/Production-guide.md
@@ -147,7 +147,7 @@ git clone https://github.com/tootsuite/mastodon.git live
 # Change directory to ~live
 cd ~/live
 # Checkout to the latest stable branch
-git checkout $(git tag -l | sort -V | tail -n 1)
+git checkout $(git describe --tags `git rev-list --tags --max-count=1`)
 # Install bundler
 gem install bundler
 # Use bundler to install the rest of the Ruby dependencies


### PR DESCRIPTION
Previous command which was `git checkout $(git tag -l | sort -V | tail -n 1)` was installing 1.6.0rc5 instead of 1.6.0. As `sort -V` was keeping 1.6.0rc5 at the top. `git checkout $(git describe --tags $(git rev-list --tags --max-count=1))` installs the last tagged version of the repository.