### PR TITLE
Don't include RCs in initial setup

### DIFF
--- a/Running-Mastodon/Production-guide.md
+++ b/Running-Mastodon/Production-guide.md
@@ -147,7 +147,7 @@ git clone https://github.com/tootsuite/mastodon.git live
 # Change directory to ~live
 cd ~/live
 # Checkout to the latest stable branch
-git checkout $(git tag -l | sort -V | tail -n 1)
+git checkout $(git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1)
 # Install bundler
 gem install bundler
 # Use bundler to install the rest of the Ruby dependencies


### PR DESCRIPTION
Fixing the same issue as d9e523ec15619ebd70f5b3fd279a2541c821c12f where the command is used in Production-guide.md