### PR TITLE
Use single quotes for pg user password

### DIFF
--- a/Running-Mastodon/PgBouncer-guide.md
+++ b/Running-Mastodon/PgBouncer-guide.md
@@ -36,7 +36,7 @@ Here's how you might reset the password:
 
 Then:
 
-    ALTER USER "mastodon" WITH PASSWORD "password";
+    ALTER USER "mastodon" WITH PASSWORD 'password';
 
 Then `\q` to quit.
 


### PR DESCRIPTION
Double quotes are not syntactically correct here.