### PR TITLE
Use nullDB during asset precompile

### DIFF
--- a/Running-Mastodon/Development-guide.md
+++ b/Running-Mastodon/Development-guide.md
@@ -35,7 +35,7 @@ You can then run Mastodon with:
 Since 1.4, we are using Webpack, which in development environment needs to be started as well as the command above:
 
     ./bin/webpack-dev-server
-    
+
 Another, optional approach to managing the different processes starting (Rails, Webpack, Sidekiq, and the Streaming API) is to use the foreman tool.
 
     gem install foreman
@@ -115,7 +115,7 @@ bundle install --with development
 yarn install --pure-lockfile
 gem install foreman --no-ri --no-rdoc
 bundle exec rails db:setup
-bin/rails assets:precompile
+DB_ADAPTER=nulldb bin/rails assets:precompile
 ```
 
 ### Running

--- a/Running-Mastodon/Docker-Guide.md
+++ b/Running-Mastodon/Docker-Guide.md
@@ -41,7 +41,7 @@ Now the image can be used to generate secrets. Run the command below for each of
 
     docker-compose run --rm web rake secret
 
-To enable Web Push notifications, you should generate a few extra secrets and put them into your `.env.production` file. Run Command below for each of `VAPID_PRIVATE_KEY` and `VAPID_PUBLIC_KEY` then copy the result into the `.env.production` file: 
+To enable Web Push notifications, you should generate a few extra secrets and put them into your `.env.production` file. Run Command below for each of `VAPID_PRIVATE_KEY` and `VAPID_PUBLIC_KEY` then copy the result into the `.env.production` file:
 
     docker-compose run --rm web rake mastodon:webpush:generate_vapid_key
 
@@ -51,7 +51,7 @@ Then you should run the `db:migrate` command to create the database, or migrate 
 
 Then, you will also need to precompile the assets:
 
-    docker-compose run --rm web rake assets:precompile
+    docker-compose run --rm web rake assets:precompile DB_ADAPTER=nulldb
 
 before you can launch the docker image with:
 
@@ -91,5 +91,5 @@ This approach makes updating to the latest version a real breeze.
 4. Only if you ran `git stash`, now run `git stash pop` to redo your changes to `docker-compose.yml`. Double check the contents of this file.
 5. `docker-compose build` to compile the Docker image out of the changed source files.
 6. (optional) `docker-compose run --rm web rake db:migrate` to perform database migrations. Does nothing if your database is up to date.
-7. (optional) `docker-compose run --rm web rake assets:precompile` to compile new JS and CSS assets.
+7. (optional) `docker-compose run --rm web rake assets:precompile DB_ADAPTER=nulldb` to compile new JS and CSS assets.
 8. `docker-compose up -d` to re-create (restart) containers and pick up the changes.

--- a/Running-Mastodon/Production-guide.md
+++ b/Running-Mastodon/Production-guide.md
@@ -240,7 +240,7 @@ server {
     add_header Cache-Control "public, max-age=31536000, immutable";
     try_files $uri @proxy;
   }
-  
+
   location /sw.js {
     add_header Cache-Control "public, max-age=0";
     try_files $uri @proxy;
@@ -431,7 +431,7 @@ RAILS_ENV=production bundle exec rails db:setup
 Then we will need to precompile all CSS and JavaScript files:
 
 ```sh
-RAILS_ENV=production bundle exec rails assets:precompile
+RAILS_ENV=production DB_ADAPTER=nulldb bundle exec rails assets:precompile
 ```
 
 **The assets precompilation takes a couple minutes, so this is a good time to take another break.**

--- a/Running-Mastodon/Updating-Mastodon-Guide.md
+++ b/Running-Mastodon/Updating-Mastodon-Guide.md
@@ -28,7 +28,7 @@ tagged release.
 Always run tagged releases on production Mastodon instances. Never run the master branch
 on your production instance.
 
-You can always use `git status` to verify what tagged release your local 
+You can always use `git status` to verify what tagged release your local
 repository copy is at, for example:
 
 ```sh
@@ -77,13 +77,13 @@ The aforementioned release notes will mention if you need to do the rest of this
 This is how you pre-compile assets:
 ```sh
 cd ~/live
-RAILS_ENV=production bundle exec rails assets:precompile
+RAILS_ENV=production DB_ADAPTER=nulldb bundle exec rails assets:precompile
 ```
 
 A caveat:
 
-The assets pre-compiler ([Webpacker](https://github.com/rails/webpacker)) can take up 
-a non-trivial amount of resources, particularly RAM. If you find that your server is 
+The assets pre-compiler ([Webpacker](https://github.com/rails/webpacker)) can take up
+a non-trivial amount of resources, particularly RAM. If you find that your server is
 running out of RAM when running the pre-compile, I recommend stopping the Mastodon services
 before starting the pre-compile.
 
@@ -94,7 +94,7 @@ systemctl stop mastodon-*
 
 ## Restarting Mastodon services
 
-Mastodon runs in memory so you will need to restart it for any of the previous updates to take 
+Mastodon runs in memory so you will need to restart it for any of the previous updates to take
 effect.
 
 This is how you restart Mastodon services (as root):


### PR DESCRIPTION
Update the docs to recommend using the nullDB driver when precompiling assets. This should result in a speed increase – and fewer build-time errors in setups without actual DB access – during asset compilation.

Requires tootsuite/mastodon#5127