### PR TITLE
Update Production-guide.md

### DIFF
--- a/Running-Mastodon/Production-guide.md
+++ b/Running-Mastodon/Production-guide.md
@@ -127,8 +127,8 @@ Now that [`rbenv`](https://github.com/rbenv/rbenv) and [`ruby-build`](https://gi
 To enable [Ruby](https://www.ruby-lang.org/en/), run:
 
 ```sh
-rbenv install 2.4.2
-rbenv global 2.4.2
+rbenv install 2.4.1
+rbenv global 2.4.1
 ```
 
 **This will take some time. Go stretch for a bit and drink some water while the commands run.**


### PR DESCRIPTION
The current latest stable branch (1.6.1) that is pulled from line 150 (git checkout $(git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1)) uses ruby version 2.4.1