### PR TITLE
Correct 'null' to 'nil' in reactivation section

### DIFF
--- a/Running-Mastodon/Administration-guide.md
+++ b/Running-Mastodon/Administration-guide.md
@@ -70,7 +70,7 @@ Additionally you can toggle the "reject media" option. When enabled, media files
 ## Reactivating a previously deleted user
 
     RAILS_ENV=production bundle exec rails c
-    account = Account.find_by(username: 'username', domain: null)
+    account = Account.find_by(username: 'username', domain: nil)
     account.suspended = false
     user = User.create!(email: 'email', password: 'password', account: account)
     user.confirm


### PR DESCRIPTION
Replaced this 'null' with a 'nil' so Ruby won't throw a NameError.