### PR TITLE
Update git clone command

### DIFF
--- a/Running-Mastodon/Docker-Guide.md
+++ b/Running-Mastodon/Docker-Guide.md
@@ -14,7 +14,7 @@ The project now includes a `Dockerfile` and a `docker-compose.yml` file (which r
 
 Clone Mastodon's repository.
 
-    git clone git@github.com:tootsuite/mastodon.git
+    git clone https://github.com/tootsuite/mastodon.git
     cd mastodon
 
 Review the settings in `docker-compose.yml`. Note that it is **not default** to store the postgresql database and redis databases in a persistent storage location. If you plan on running your instance in production, you **must** uncomment the [`volumes` directive](https://github.com/tootsuite/mastodon/blob/972f6bc861affd9bc40181492833108f905a04b6/docker-compose.yml#L7-L16) in `docker-compose.yml`.


### PR DESCRIPTION
using https link for git clone

When using git link, users must set their ssh key setting in github setting, 
so, it may be better using a https link for `git clone`