### PR TITLE
Added note for server admins on HSTS configuration

### DIFF
--- a/Running-Mastodon/Production-guide.md
+++ b/Running-Mastodon/Production-guide.md
@@ -286,6 +286,7 @@ server {
   error_page 500 501 502 503 504 /500.html;
 }
 ```
+**Note: By default, ruby automatically creates an [HSTS header](https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security) for connections at the application level. If you are rolling your own SSL configuration in Nginx, care must be taken to not duplicate the HSTS header setting. Otherwise, [an invalid configuration may result](https://github.com/ssllabs/ssllabs-scan/issues/294).** This issue will impact your SSL quality score as your server would be returning two seperate HSTS headers.
 
 Activate the [nginx](http://nginx.org) configuration added:
 


### PR DESCRIPTION
Self explanatory. I was checking the SSL configuration of my instance using the [SSL-labs test tool](https://www.ssllabs.com/ssltest/analyze.html?d=mastodon.hong.io) when I noticed an invalid HSTS configuration warning, where my server was sending two HSTS headers.

Upon a brief search, it turns out that ruby (or is it ruby-on-rails?) [appends an HSTS header by default](https://github.com/ssllabs/ssllabs-scan/issues/294#issuecomment-182454510) to the connection, which seems to be the case on mastodon.

I've modified the installation documentation accordingly, so sysadmins and instance maintainers will take note.