### PR TITLE
[Apache] Allow access the streaming API with both HTTP and WS

### DIFF
--- a/Running-Mastodon/Alternatives.md
+++ b/Running-Mastodon/Alternatives.md
@@ -223,8 +223,17 @@ Setting up Mastodon behind Apache is possible as well, although you will need to
    ProxyPassMatch ^(/.*\.(png|ico)$) !
    ProxyPassMatch ^/(assets|avatars|emoji|headers|packs|sounds|system|.well-known/acme-challenge) !
    
-   ProxyPass /api/v1/streaming/ ws://localhost:4000/
-   ProxyPassReverse /api/v1/streaming/ ws://localhost:4000/
+   RewriteEngine on
+
+   # Allows use of both ws and http for the streaming API
+   RewriteCond %{HTTP:Connection} Upgrade [NC]
+   RewriteCond %{HTTP:Upgrade} websocket [NC]
+   RewriteRule /api/v1/streaming/(.*) ws://127.0.0.1:4000/api/v1/streaming/$1 [QSA,P]
+
+   # This directive isn't used if the RewriteRule one was matched
+   ProxyPass /api/v1/streaming/ http://127.0.0.1:4000/api/v1/streaming/
+   ProxyPassReverse /api/v1/streaming/ http://127.0.0.1:4000/api/v1/streaming/
+
    ProxyPass / http://localhost:3000/
    ProxyPassReverse / http://localhost:3000/
 


### PR DESCRIPTION
The previous configuration example allowed the streaming API to be accessed with websockets only. It's because Apache stops at the first matching "ProxyPass" directive which forward to a ws:// URL. This is problematic for apps (such as [Mastalab](https://github.com/stom79/mastalab/)) who calls the streaming API with "normal" HTTP requests only.

To work around that, I use RewriteCond/RewriteRule directives who matches websockets requests to the streaming API. The following ProxyPass directive is then used only if the RewriteRule didn't match the request (=non-ws requests).