### PR TITLE
fix example of nginx config in production guide

### DIFF
--- a/Running-Mastodon/Production-guide.md
+++ b/Running-Mastodon/Production-guide.md
@@ -238,13 +238,13 @@ server {
     try_files $uri @proxy;
   }
 
-  location ~ ^/(emoji|packs|system/accounts/avatars|system/media_attachments/files) {
-    add_header Cache-Control "public, max-age=31536000, immutable";
+  location ~ ^/(sw.js|packs/manifest.json)$ {
+    add_header Cache-Control "public, max-age=0";
     try_files $uri @proxy;
   }
-  
-  location /sw.js {
-    add_header Cache-Control "public, max-age=0";
+
+  location ~ ^/(emoji|packs|system/accounts/avatars|system/media_attachments/files) {
+    add_header Cache-Control "public, max-age=31536000, immutable";
     try_files $uri @proxy;
   }
 


### PR DESCRIPTION
`/packs/manifest.json` will change when execute `bundle ex rails assets:precompile`.
However, it was cached with "max-age=31536000".