### PR TITLE
Added change for CentOS 7 distro

### DIFF
--- a/Running-Mastodon/Production-guide.md
+++ b/Running-Mastodon/Production-guide.md
@@ -357,7 +357,11 @@ Copy and paste this script into that file:
 letsencrypt renew
 systemctl reload nginx
 ```
-
+For CentOS 7:
+```sh
+#!/usr/bin/env bash
+letsencrypt renew --pre-hook "service nginx stop" --post-hook "service nginx start"
+```
 Save and exit the file.
 
 Make the script executable and restart the cron daemon so that the script runs daily:


### PR DESCRIPTION
Fix for issue #478.  This should really be fixed upstream with certbot, as downtime for swapping certs just shouldn't be required.