### PR TITLE
Fix /api/v1/accounts/:id/lists docs

### DIFF
--- a/Using-the-API/API.md
+++ b/Using-the-API/API.md
@@ -613,7 +613,7 @@ Returns at most 50 [Lists](#list) without pagination.
 
     GET /api/v1/accounts/:id/lists
     
-Returns at most 50 [Accounts](#account) without pagination.
+Returns at most 50 [Lists](#list) without pagination.
 
 #### Retrieving accounts in a list
 


### PR DESCRIPTION
It returns Lists, not Accounts.