### PR TITLE
Updates Status.emojis information

### DIFF
--- a/Using-the-API/API.md
+++ b/Using-the-API/API.md
@@ -819,7 +819,7 @@ The most important part of an error response is the HTTP status code. Standard s
 | `reblog`                 | `null` or the reblogged [Status](#status)                                     | yes      |
 | `content`                | Body of the status; this will contain HTML (remote HTML already sanitized)    | no       |
 | `created_at`             | The time the status was created                                               | no       |
-| `emojis`                 | An array of [Emoji](#emoji)                                                   | yes      |
+| `emojis`                 | An array of [Emoji](#emoji)                                                   | no       |
 | `reblogs_count`          | The number of reblogs for the status                                          | no       |
 | `favourites_count`       | The number of favourites for the status                                       | no       |
 | `reblogged`              | Whether the authenticated user has reblogged the status                       | yes      |


### PR DESCRIPTION
`emojis` is not nullable. Instead, it returns an empty array when no emojis are used (which is consistent with other fields that return array of objects, for instance `media_attachments `, `mentions `, and `tags`).

```
    "media_attachments": [],
    "mentions": [],
    "tags": [],
    "emojis": []
```