### PR TITLE
Update Apps.md

### DIFF
--- a/Using-Mastodon/Apps.md
+++ b/Using-Mastodon/Apps.md
@@ -111,6 +111,7 @@ Some people have started working on apps for the Mastodon API. Here is a list of
 |**[t2m – Twitter 2 Mastodon](https://github.com/Psycojoker/t2m/blob/master/README.md)**|CLI|<https://github.com/Psycojoker/t2m>|Psycojoker|
 |**[umrc](https://github.com/Ulrar/umrc/blob/master/README.md)**|IRC|<https://github.com/Ulrar/umrc>|[@lemonnierk@ulrar.net](https://mastodon.ulrar.net/users/lemonnierk)|
 |**[WordPress](http://mastodon.tools/wordpress/)**|WordPress plugin|<https://github.com/DavidLibeau/mastodon-tools/tree/master/wordpress>|[@David@mastodon.xyz](https://mastodon.xyz/@David)|
+|**[Mastodon Embed Improved](https://f2w.de/mastodon-embed)**|WordPress plugin|<https://github.com/ginsterbusch/mastodon-embed>|[@ginsterbusch@kosmos.social](https://kosmos.social/@ginsterbusch)|
 |[ogp-share](http://mastodon.tools/ogp-share/) *(beta)*|Web browser|<https://github.com/DavidLibeau/mastodon-tools/tree/master/ogp-share>|[@David@mastodon.xyz](https://mastodon.xyz/@David)|
 
 ## Bots


### PR DESCRIPTION
adds Mastodon Embed Improved, an helper plugin to embed toots in WordPress posts (strongly inspired by mastodon-tools by David Libeau)