### PR TITLE
Adds following parameter in /accounts/search

### DIFF
--- a/Using-the-API/API.md
+++ b/Using-the-API/API.md
@@ -208,6 +208,7 @@ Query parameters:
 | ----------------- | ------------------------------------------------------------- | ---------- |
 | `q`               | What to search for                                            | no         |
 | `limit`           | Maximum number of matching accounts to return (default: `40`) | yes        |
+| `following`       | Limit the search to following (boolean, default `false`)      | yes        |
 
 Returns an array of matching [Accounts](#accounts).
 


### PR DESCRIPTION
`following` parameter allows to search users for adding them to a list.