### PR TITLE
apache config fix.

### DIFF
--- a/Running-Mastodon/Alternatives.md
+++ b/Running-Mastodon/Alternatives.md
@@ -209,6 +209,7 @@ Setting up Mastodon behind Apache is possible as well, although you will need to
    
    <LocationMatch "^/(assets|avatars|emoji|headers|packs|sounds|system)>
       Header always set Cache-Control "public, max-age=31536000, immutable"
+      Require all granted
    </LocationMatch>
 
    ProxyPreserveHost On


### PR DESCRIPTION
I had to add

```
Require all granted
```

today after installation in order for my mastodon instance to work.
otherwise there was no access to assets, no graphics on the registration page, nothing after registration.