### PR TITLE
Update instructions for Let's Encrypt renewal

### DIFF
--- a/Running-Mastodon/Production-guide.md
+++ b/Running-Mastodon/Production-guide.md
@@ -344,26 +344,27 @@ letsencrypt certonly --webroot -d example.com -w /home/mastodon/live/public/
 
 You need to renew your certificate before the expiration date. Not doing so will make users of your instance unable to access the instance and users of other instances unable to federate with yours.
 
-We can create a cron job that runs daily to do this:
+We can create a cron job that runs monthly to do this:
 
 ```sh
-nano /etc/cron.daily/letsencrypt-renew
+nano /etc/cron.monthly/letsencrypt-renew
 ```
 
 Copy and paste this script into that file:
 
 ```sh
 #!/usr/bin/env bash
+systemctl stop nginx
 letsencrypt renew
-systemctl reload nginx
+systemctl start nginx
 ```
 
 Save and exit the file.
 
-Make the script executable and restart the cron daemon so that the script runs daily:
+Make the script executable and restart the cron daemon so that the script runs monthly:
 
 ```sh
-chmod +x /etc/cron.daily/letsencrypt-renew
+chmod +x /etc/cron.monthly/letsencrypt-renew
 systemctl restart cron
 ```
 


### PR DESCRIPTION
The main issue with the current instructions is that nginx needs to be stopped before `letsencrypt renew` can run, otherwise you get an error like this:

```
2018-01-25 02:23:11,991:WARNING:letsencrypt.cli:Attempting to renew cert from /etc/letsencrypt/renewal/mastodon.example.com.conf produced an unexpected error: At least one of the (possibly) required ports is already taken.. Skipping.
```

Also, since we want to keep the server downtime to a minimum, we move the renewal it to the monthly cron.