### PR TITLE
Update ruby version in production guide

### DIFF
--- a/Running-Mastodon/Production-guide.md
+++ b/Running-Mastodon/Production-guide.md
@@ -129,8 +129,8 @@ Now that [`rbenv`](https://github.com/rbenv/rbenv) and [`ruby-build`](https://gi
 To enable [Ruby](https://www.ruby-lang.org/en/), run:
 
 ```sh
-rbenv install 2.4.2
-rbenv global 2.4.2
+rbenv install 2.5.0
+rbenv global 2.5.0
 ```
 
 **This will take some time. Go stretch for a bit and drink some water while the commands run.**

--- a/Using-Mastodon/Apps.md
+++ b/Using-Mastodon/Apps.md
@@ -133,7 +133,7 @@ Some people have started working on apps for the Mastodon API. Here is a list of
 |[Scheduler](http://mastodon.tools/scheduler/) *(beta)*|Web browser|<https://github.com/DavidLibeau/mastodon-scheduler>|[@David@mastodon.xyz](https://mastodon.xyz/@David)|
 |**[Tootmap](https://tootmap.net/)**|Web browser|<https://github.com/wakin-/Tootmap>|[@wakin@biwakodon.com](https://biwakodon.com/@wakin)|
 |**[Mastodon User Matching](http://vinayaka.distsn.org/)**|Web browser|<https://github.com/distsn/vinayaka>|[@hakabahitoyo@2.distsn.org](https://2.distsn.org/@hakabahitoyo)|
+|**[MastoPurge](https://github.com/ThomasLeister/mastopurge)**|CLI|<https://github.com/ThomasLeister/mastopurge>|[Thomas Leister](https://thomas-leister.de/en/about-me/)|
 |[mastodon-archive](https://github.com/kensanata/mastodon-backup#mastodon-archive)|CLI|<https://github.com/kensanata/mastodon-backup#mastodon-archive>|[Alex Schroeder](https://alexschroeder.ch/wiki/Contact)|
-|[MastoPurge](https://github.com/ThomasLeister/mastopurge)|CLI|<https://github.com/ThomasLeister/mastopurge>|[Thomas Leister](https://thomas-leister.de/en/about-me/)|
 
 If you have a project like this, make a PR to add it to the list!

--- a/Using-Mastodon/Apps.md
+++ b/Using-Mastodon/Apps.md
@@ -134,5 +134,6 @@ Some people have started working on apps for the Mastodon API. Here is a list of
 |**[Tootmap](https://tootmap.net/)**|Web browser|<https://github.com/wakin-/Tootmap>|[@wakin@biwakodon.com](https://biwakodon.com/@wakin)|
 |**[Mastodon User Matching](http://vinayaka.distsn.org/)**|Web browser|<https://github.com/distsn/vinayaka>|[@hakabahitoyo@2.distsn.org](https://2.distsn.org/@hakabahitoyo)|
 |[mastodon-archive](https://github.com/kensanata/mastodon-backup#mastodon-archive)|CLI|<https://github.com/kensanata/mastodon-backup#mastodon-archive>|[Alex Schroeder](https://alexschroeder.ch/wiki/Contact)|
+|[MastoPurge](https://github.com/ThomasLeister/mastopurge)|CLI|<https://github.com/ThomasLeister/mastopurge>|[Thomas Leister](https://thomas-leister.de/en/about-me/)|
 
 If you have a project like this, make a PR to add it to the list!


### PR DESCRIPTION
Updates Ruby version from 2.4.2 to 2.5.0. Subsequent commands will fail otherwise.