### PR TITLE
Update Mac instructions to have users install Ruby 2.5.0

### DIFF
--- a/Running-Mastodon/Development-guide.md
+++ b/Running-Mastodon/Development-guide.md
@@ -120,7 +120,7 @@ These are self-contained instructions for setting up a development environment o
 
 	```
 	rbenv init
-	rbenv install 2.4.1
+	rbenv install 2.5.0
 	```
 
 - Install/configure bundler to use your local rbenv:


### PR DESCRIPTION
Based on the `.ruby-version` in the root of the Mastodon codebase and the "ruby-2.5.0 is not installed." message I got when changing to that directory I assume that the documentation should now instruct potential devs to install ruby 2.5.0.