### PR TITLE
Use db:setup instead of db:migrate when creating the database

### DIFF
--- a/Running-Mastodon/Docker-Guide.md
+++ b/Running-Mastodon/Docker-Guide.md
@@ -45,9 +45,9 @@ To enable Web Push notifications, you should generate a private/public key pair 
 
     docker-compose run --rm web rake mastodon:webpush:generate_vapid_key
 
-Then you should run the `db:migrate` command to create the database, or migrate it from an older release:
+Then you should run the `db:setup` command to create the database:
 
-    docker-compose run --rm web rake db:migrate
+    docker-compose run --rm web rake db:setup
 
 Then, you will also need to precompile the assets:
 


### PR DESCRIPTION
db:setup is used in all guides except Docker Guide, which uses db:migrate
to create the database. db:setup is actually superior over db:migrate for
the purpose in terms of performance and compatibility.

db:setup is performant because it does not perform redundant migrations.
db:migrate, on the other hand, executes migration code which will be
dismissed by later migrations. db:migrate also waits for seconds to allow
to interrupt migrations if it is not favorable to run them on a running
server, but db:setup is obviously executed on a instance which is not
running yet, and the wait is unnecessary.

db:migrate has a compatibility issue. It requires a compatibility layer
to keep it working, and such one may be broken, or not provided by
dependencies such as Paperclip.

This commit replaces db:migrate with db:setup in the building guide. The
procedure cannot be applied to migration from an older release, where
the old procedure could, but it is not problematic because it has
dedicated Updating section.