### PR TITLE
apt install openjdk-8-jre-headless

### DIFF
--- a/Running-Mastodon/Elasticsearch-guide.md
+++ b/Running-Mastodon/Elasticsearch-guide.md
@@ -16,7 +16,7 @@ Elasticsearch is built using Java, and requires at least Java 8 in order to run.
 Install Java 8:
 
 ```
-sudo apt install openjdk-8-jre
+sudo apt install openjdk-8-jre-headless
 ```
 
 > The openjdk-8-jre package contains just the Java Runtime Environment. If you want to develop Java programs then please install the openjdk-8-jdk package.


### PR DESCRIPTION
Without headless a lot of (for a server) unneeded dependencies needs be installed (on Debian stretch), like icon sets and x11-utils. Elasticsearch works without problems when you only install openjdk-8-jre-headless (that has much less dependencies).