### PR TITLE
Limit client max body size in the nginx configuration example

### DIFF
--- a/Running-Mastodon/Production-guide.md
+++ b/Running-Mastodon/Production-guide.md
@@ -227,7 +227,7 @@ server {
 
   keepalive_timeout    70;
   sendfile             on;
-  client_max_body_size 0;
+  client_max_body_size 8m;
 
   root /home/mastodon/live/public;
 


### PR DESCRIPTION
As Mastodon temporaliry saves uploaded content to memory and disk (if
/tmp is a disk), unlimiting client max body size makes the server
vulnerable to DoS attack.

cc: @Gargron 