### PR TITLE
Add mastodon-jfx to Apps list

### DIFF
--- a/Using-Mastodon/Apps.md
+++ b/Using-Mastodon/Apps.md
@@ -84,12 +84,14 @@ List of apps
 |---|-----------|------------|
 |**[Mstdn](https://github.com/rhysd/Mstdn/blob/master/README.md)** | <https://github.com/rhysd/Mstdn>|[@Linda_pp@mstdn.jp](https://mstdn.jp/@Linda_pp)/[@inudog@mastodon.social](https://mastodon.social/@inudog) |
 |[TheDesk](https://github.com/cutls/TheDesk/blob/master/README.md) | <https://github.com/cutls/TheDesk>|[@Cutls@kirishima.cloud](https://kirishima.cloud/@Cutls) |
+|[mastodon-jfx](https://github.com/wakingrufus/mastodon-jfx) | <https://github.com/wakingrufus/mastodon-jfx>|[@wakingrufus@mastodon.technology](https://mastodon.technology/@wakingrufus) |
 
 ### Mac ###
 
 |App|Source code|Developer(s)|
 |---|-----------|------------|
 |**[Mstdn](https://github.com/rhysd/Mstdn/blob/master/README.md)** | <https://github.com/rhysd/Mstdn>|[@Linda_pp@mstdn.jp](https://mstdn.jp/@Linda_pp)/[@inudog@mastodon.social](https://mastodon.social/@inudog) |
+|[mastodon-jfx](https://github.com/wakingrufus/mastodon-jfx) | <https://github.com/wakingrufus/mastodon-jfx>|[@wakingrufus@mastodon.technology](https://mastodon.technology/@wakingrufus) |
 
 ### Windows
 
@@ -102,6 +104,7 @@ List of apps
 |**[WinMasto](https://github.com/drasticactions/WinMasto/blob/master/README.md)**|10|<https://github.com/drasticactions/WinMasto>|[@drasticactions@mastodon.network](https://mastodon.network/users/drasticactions)|
 |[Mastodon UWP](https://rink.hockeyapp.net/apps/5199eba8bc914c4ab416aa8513d62826) *(beta)*|10|<https://github.com/woachk/mastodon>|[@my123@mastodon.social](https://mastodon.social/users/my123)|
 |[TheDesk](https://github.com/cutls/TheDesk/blob/master/README.md) |7~ |<https://github.com/cutls/TheDesk>|[@Cutls@kirishima.cloud](https://kirishima.cloud/@Cutls) |
+|[mastodon-jfx](https://github.com/wakingrufus/mastodon-jfx) | <https://github.com/wakingrufus/mastodon-jfx>|[@wakingrufus@mastodon.technology](https://mastodon.technology/@wakingrufus) |
 
 ## Alternative web clients
 


### PR DESCRIPTION
mastodon-jfx is a desktop client for Mastodon written in kotlin using TornadoFX. It is designed for power tooters, particularly ones with multiple accounts spanning multiple instances. It is currently in an Alpha state. It is not yet feature-complete and the Look & Feel is in progress.