### PR TITLE
Refreshed Halcyon entry in Apps.md

### DIFF
--- a/Using-Mastodon/Apps.md
+++ b/Using-Mastodon/Apps.md
@@ -109,7 +109,7 @@ List of apps
 
 |App|Source code|Developer(s)|
 |---|-----------|------------|
-|**[Halcyon](https://halcyon.social)**|<https://github.com/halcyon-suite/halcyon>|[@halcyon@mastodon.social](https://mastodon.social/@halcyon)|
+|**[Halcyon](https://halcyon.toromino.de)**|<https://github.com/halcyon-suite/halcyon>|[@halcyon@social.csswg.org](https://social.csswg.org/@halcyon)|
 |[Naumanni](https://naumanni.com/) *(alpha)*|<https://github.com/naumanni/naumanni>|[@shi3z@mstdn.onosendai.jp](https://mstdn.onosendai.jp/@shi3z)/[@shn@oppai.tokyo](https://oppai.tokyo/@shn)|
 |[Pinafore](https://pinafore.social/) *(beta)*|<https://github.com/nolanlawson/pinafore>|[@nolan@toot.cafe](https://toot.cafe/@nolan)|
 


### PR DESCRIPTION
The link to the official Halcyon instance was broken and was replaced by one provided by a third party.
The link to the Halcyon account on Mastodon was outdated and was replaced by the current one.