### PR TITLE
Adding copy config step

### DIFF
--- a/Running-Mastodon/Docker-Guide.md
+++ b/Running-Mastodon/Docker-Guide.md
@@ -47,7 +47,13 @@ You must build your own image if you've made any code modifications. To build yo
 
 ## Building the app
 
-Now the image can be used to generate a configuration with:
+Let's start the configuration part by generating some secret keys. Run the following command *twice*:
+
+    docker-compose run --rm web rake secret
+
+Take these two keys and put them into `.env.production` values `SECRET_KEY_BASE` and `OTP_SECRET`.
+
+Now the image can be used to generate the rest of the configuration with:
 
     docker-compose run --rm web rake mastodon:setup
 

--- a/Running-Mastodon/Docker-Guide.md
+++ b/Running-Mastodon/Docker-Guide.md
@@ -48,13 +48,7 @@ You must build your own image if you've made any code modifications. To build yo
 
 ## Building the app
 
-Let's start the configuration part by generating some secret keys. Run the following command *twice*:
-
-    docker-compose run --rm web rake secret
-
-Take these two keys and put them into `.env.production` values `SECRET_KEY_BASE` and `OTP_SECRET`.
-
-Now the image can be used to generate the rest of the configuration with:
+Now the image can be used to generate a configuration with:
 
     docker-compose run --rm web rake mastodon:setup
 

--- a/Running-Mastodon/Docker-Guide.md
+++ b/Running-Mastodon/Docker-Guide.md
@@ -33,6 +33,7 @@ To use the prebuilt images:
    3. Save the file and exit the text editor.
 2. Run `cp .env.production.sample .env.production` to bootstrap the configuration. You will need to edit this file later.
 3. Run `docker-compose build`. It will now pull the correct image from Docker Hub.
+4. Set correct file-owner with `chown -R 991:991 public`
 
 ### Building your own image
 

--- a/Running-Mastodon/Docker-Guide.md
+++ b/Running-Mastodon/Docker-Guide.md
@@ -28,18 +28,20 @@ If you're not making any local code changes or customizations on your instance, 
 To use the prebuilt images:
 
 1. Open `docker-compose.yml` in your favorite text editor.
-2. Comment out the `build: .` lines for all images (web, streaming, sidekiq).
-3. Edit the `image: tootsuite/mastodon` lines for all images to include the release you want. The default is `latest` which is the most recent stable version, however it recommended to explicitly pin a version: If you wanted to use v2.2.0 for example, you would edit the lines to say: `image: tootsuite/mastodon:v2.2.0`
-4. Save the file and exit the text editor.
-4. Run `docker-compose build`. It will now pull the correct image from Docker Hub.
+   1. Comment out the `build: .` lines for all images (web, streaming, sidekiq).
+   2. Edit the `image: tootsuite/mastodon` lines for all images to include the release you want. The default is `latest` which is the most recent stable version, however it recommended to explicitly pin a version: If you wanted to use v2.2.0 for example, you would edit the lines to say: `image: tootsuite/mastodon:v2.2.0`
+   3. Save the file and exit the text editor.
+2. Run `cp .env.production.sample .env.production` to bootstrap the configuration. You will need to edit this file later.
+3. Run `docker-compose build`. It will now pull the correct image from Docker Hub.
 
 ### Building your own image
 
 You must build your own image if you've made any code modifications. To build your own image:
 
 1. Open `docker-compose.yml` in your favorite text editor.
-2. Uncomment the `build: .` lines for all images (web, streaming, sidekiq) if needed.
-3. Save the file and exit the text editor.
+   1. Uncomment the `build: .` lines for all images (web, streaming, sidekiq) if needed.
+   2. Save the file and exit the text editor.
+2. Run `cp .env.production.sample .env.production` to bootstrap the configuration. You will need to edit this file later.
 3. Run `docker-compose build`.
 4. Set correct file-owner with `chown -R 991:991 public`
 


### PR DESCRIPTION
As discussed in #591, docker will refuse to run the `mastodon:setup` step without some configuration file present.