### PR TITLE
The only_media query param is public and tag only

### DIFF
--- a/Using-the-API/API.md
+++ b/Using-the-API/API.md
@@ -684,7 +684,7 @@ Query parameters:
 | Field             | Description                                                                         | Optional   |
 | ----------------- | ----------------------------------------------------------------------------------- | ---------- |
 | `local`           | Only return statuses originating from this instance (public and tag timelines only) | yes        |
-| `only_media`      | Only return statuses that have media attachments                                    | yes        |
+| `only_media`      | Only return statuses that have media attachments (public and tag timelines only)    | yes        |
 | `max_id`          | Get a list of timelines with ID less than this value                                | yes        |
 | `since_id`        | Get a list of timelines with ID greater than this value                             | yes        |
 | `limit`           | Maximum number of statuses on the requested timeline to get (Default 20, Max 40)    | yes        |


### PR DESCRIPTION
Per [a discussion elsewhere], the `only_media` query param does not work
on the home timeline API.

[a discussion elsewhere]: https://github.com/tootsuite/mastodon/issues/6603#issuecomment-383099654