### PR TITLE
Changed link to Halcyon repository in Apps.md

### DIFF
--- a/Using-Mastodon/Apps.md
+++ b/Using-Mastodon/Apps.md
@@ -110,7 +110,7 @@ List of apps
 
 |App|Source code|Developer(s)|
 |---|-----------|------------|
-|**[Halcyon](https://halcyon.toromino.de)**|<https://github.com/halcyon-suite/halcyon>|[@halcyon@social.csswg.org](https://social.csswg.org/@halcyon)|
+|**[Halcyon](https://halcyon.toromino.de)**|<https://notabug.org/halcyon-suite/halcyon>|[@halcyon@social.csswg.org](https://social.csswg.org/@halcyon)|
 |[Naumanni](https://naumanni.com/) *(alpha)*|<https://github.com/naumanni/naumanni>|[@shi3z@mstdn.onosendai.jp](https://mstdn.onosendai.jp/@shi3z)/[@shn@oppai.tokyo](https://oppai.tokyo/@shn)|
 |[Pinafore](https://pinafore.social/) *(beta)*|<https://github.com/nolanlawson/pinafore>|[@nolan@toot.cafe](https://toot.cafe/@nolan)|
 


### PR DESCRIPTION
As Github has been bought by Microsoft,I've decided to move the Halcyon repository to an new open and trustworthy home.
This move is confirmed by the announcement of the official Halcyon account: https://social.csswg.org/users/halcyon/statuses/100153247871238507
Additionally this change has been noted in the old Github repository.
Please change the link to the new one.