### PR TITLE
Add custom request entity too large error to nginx

### DIFF
--- a/Running-Mastodon/Production-guide.md
+++ b/Running-Mastodon/Production-guide.md
@@ -283,8 +283,14 @@ server {
 
     tcp_nodelay on;
   }
+  
+  location @change_upload_error {
+    default_type application/json;
+    return 422 "{\"error\":\"Validation failed: File file size must be less than 8 MB, File must be less than 8 MB\"}";
+  }
 
   error_page 500 501 502 503 504 /500.html;
+  error_page 413 = @change_upload_error;
 }
 ```
 


### PR DESCRIPTION
After https://github.com/tootsuite/documentation/commit/8ab12a626e5a57902fc7e87b3ba9870e57fc4537 the production guide recommends limiting nginx to accepting 8mb uploads. The problem is that in that case nginx returns 413 with a HTML body.
In that case, the mastodon-api gem and probably other tools that expect the API to always return a json response fail.

This adds a custom nginx error in that case copying the original error.