### PR TITLE
Update development guide with dependencies for PAM auth testing

### DIFF
--- a/Running-Mastodon/Development-guide.md
+++ b/Running-Mastodon/Development-guide.md
@@ -45,6 +45,11 @@ Finally, open `http://localhost:3000` in your browser.
 
 By default, your development environment will have an admin account created for you to use - the email address will be `admin@YOURDOMAIN` (e.g. admin@localhost:3000) and the password will be `mastodonadmin`.
 
+For the test suite, by default `.env.test` will enable testing for the optional PAM authentication. Install the system and gem group dependency with the following:
+
+    apt install libpam0g-dev
+    bundle install --with pam_authentication
+
 You can run tests with:
 
     rspec


### PR DESCRIPTION
Hello Mastodon team, I am new to the Mastodon software project. Through following and setting up my local development environment with the instructions in `Development-guide.md` and `Production-guide.md`, I was able to successfully get everything running except the RSpec test suite. I traced the problem to the addition and changes of PAM in tootsuite/mastodon#7028.

By default, `env.test` will test PAM authentication so new developers setting up their environment may run into missing dependencies problems.

* system dependency libpam
* optional gem group pam_authentication

I came across this [gist](https://gist.github.com/zunda/aa6870d0f9f68e705d54d1fa882b0cc0) from a Mastodon contributor that pointed me in the right direction after I read through the various discussions on PAM authentication from the main repo.

I have added in the two optional instructions in this commit to solve the problem of new dev environments failing the RSpec test suite due to the missing dependencies.

```
apt install libpam0g-dev
bundle install --with pam_authentication
``` 

This is my first ever pull request. Please leave any feedback. Thank you.

- [x] Have you followed the [guidelines for contributing](https://github.com/tootsuite/mastodon/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/tootsuite/documentation/pulls) for the same update/change?
 