### PR TITLE
Fix Apache configuration for protocol proxies

### DIFF
--- a/Running-Mastodon/Alternatives.md
+++ b/Running-Mastodon/Alternatives.md
@@ -224,6 +224,7 @@ Setting up Mastodon behind Apache is possible as well, although you will need to
    ProxyPassMatch ^(/.*\.(png|ico)$) !
    ProxyPassMatch ^/(assets|avatars|emoji|headers|packs|sounds|system|.well-known/acme-challenge) !
    
+   ProxyPassMatch /api/v1/streaming/(.+)$ http://localhost:4000/api/v1/streaming/$1
    ProxyPass /api/v1/streaming/ ws://localhost:4000/
    ProxyPassReverse /api/v1/streaming/ ws://localhost:4000/
    ProxyPass / http://localhost:3000/


### PR DESCRIPTION
Some requests to the node server are available via http protocol, only the `/api/v1/streaming/` is served via websocket, all other sub-urls are served over http (according to `streaming/index.js`)

(This fixes an issue that makes the tootstream tool "stream" command fail for such instances behind an apache server)