### PR TITLE
Update rbenv ruby version

### DIFF
--- a/Running-Mastodon/Development-guide.md
+++ b/Running-Mastodon/Development-guide.md
@@ -120,7 +120,7 @@ These are self-contained instructions for setting up a development environment o
 
 	```
 	rbenv init
-	rbenv install 2.5.0
+	rbenv install 2.5.1
 	```
 
 - Install/configure bundler to use your local rbenv:


### PR DESCRIPTION
The rbenv ruby install command in the Development Guide is actually _older_ than the version in the Production Guide. This change matches the versions (2.5.1, newest, the one that already is in the Production Guide.)