### PR TITLE
Fix sidekiq queues ordering in production guide

### DIFF
--- a/Running-Mastodon/Production-guide.md
+++ b/Running-Mastodon/Production-guide.md
@@ -437,7 +437,7 @@ User=mastodon
 WorkingDirectory=/home/mastodon/live
 Environment="RAILS_ENV=production"
 Environment="DB_POOL=5"
-ExecStart=/home/mastodon/.rbenv/shims/bundle exec sidekiq -c 5 -q default -q mailers -q pull -q push
+ExecStart=/home/mastodon/.rbenv/shims/bundle exec sidekiq -c 5 -q default -q push -q pull -q mailers
 TimeoutSec=15
 Restart=always
 

--- a/Running-Mastodon/Production-guide.md
+++ b/Running-Mastodon/Production-guide.md
@@ -437,7 +437,7 @@ User=mastodon
 WorkingDirectory=/home/mastodon/live
 Environment="RAILS_ENV=production"
 Environment="DB_POOL=5"
-ExecStart=/home/mastodon/.rbenv/shims/bundle exec sidekiq -c 5 -q default -q push -q pull -q mailers
+ExecStart=/home/mastodon/.rbenv/shims/bundle exec sidekiq -c 5 -q default -q push -q mailers -q pull
 TimeoutSec=15
 Restart=always
 


### PR DESCRIPTION
The ordering defines the priority, and the code expects default > push > pull > mailers