### PR TITLE
Can't add Node.js Repository Fix

### DIFF
--- a/Running-Mastodon/Production-guide.md
+++ b/Running-Mastodon/Production-guide.md
@@ -66,7 +66,7 @@ We run this script to add the repository:
 
 ```sh
 apt -y install curl
-curl -sL https://deb.nodesource.com/setup_8.x | bash -
+curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
 ```
 
 The [node.js](https://nodejs.org/en/) repository is now added.


### PR DESCRIPTION
I kept seeing the following Error:
'''
## Installing the NodeSource Node.js 8.x LTS Carbon repo...


## Populating apt-get cache...

+ apt-get update
Reading package lists... Done
E: Could not open lock file /var/lib/apt/lists/lock - open (13: Permission denied)
E: Unable to lock directory /var/lib/apt/lists/
W: Problem unlinking the file /var/cache/apt/pkgcache.bin - RemoveCaches (13: Permission denied)
W: Problem unlinking the file /var/cache/apt/srcpkgcache.bin - RemoveCaches (13: Permission denied)
'''
So I found the solution on how to fix it here:
https://www.tecmint.com/install-nodejs-npm-in-centos-ubuntu/

This fixes my Node.JS repository addition.