### PR TITLE
Tell User to Switch to The Mastodon User Again

### DIFF
--- a/Running-Mastodon/Production-guide.md
+++ b/Running-Mastodon/Production-guide.md
@@ -125,7 +125,7 @@ git clone https://github.com/rbenv/rbenv.git ~/.rbenv
 cd ~/.rbenv && src/configure && make -C src
 echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc
 echo 'eval "$(rbenv init -)"' >> ~/.bashrc
-# Restart shell
+# Restart shell and switch to the mastodon user again
 exec bash
 # Check if rbenv is correctly installed
 type rbenv


### PR DESCRIPTION
If I followed the instructions exactly, after restarting the shell, I would be back as the non-mastodon user. I think the intention may be to become a maston user again.