### PR TITLE
misleading cd

### DIFF
--- a/Running-Mastodon/Docker-Guide.md
+++ b/Running-Mastodon/Docker-Guide.md
@@ -14,10 +14,9 @@ The project now includes a `Dockerfile` and a `docker-compose.yml` file (which r
 
 Clone Mastodon's repository.
     
-    # Clone mastodon to ~/live directory
+    # Clone mastodon to live directory
     git clone https://github.com/tootsuite/mastodon.git live
-    # Change directory to ~/live
-    cd ~/live
+    cd live
     # Checkout to the latest stable branch
     git checkout $(git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1)
     


### PR DESCRIPTION
BUG: the proposed command only worked if the starting directory was $HOME.

FIX:

Changing this here will make the installation procedure independent on starting at the home directory. Git Repo can now be cloned to any subdirectory of the current path.