### PR TITLE
Added direct messages to API documentation

### DIFF
--- a/Using-the-API/API.md
+++ b/Using-the-API/API.md
@@ -826,6 +826,7 @@ Returns the target [Status](#status).
     GET /api/v1/timelines/public
     GET /api/v1/timelines/tag/:hashtag
     GET /api/v1/timelines/list/:list_id
+    GET /api/v1/timelines/direct
 
 Query parameters:
 

--- a/Using-the-API/Streaming-API.md
+++ b/Using-the-API/Streaming-API.md
@@ -25,6 +25,10 @@ Returns all public statuses for a particular hashtag (query param `tag`)
 
 Returns statuses for list (query param `list`)
 
+**GET /api/v1/streaming/direct**
+
+Returns all direct messages
+
 ### Stream contents
 
 The stream will contain events as well as heartbeat comments. Lines that begin with a colon (`:`) can be ignored by parsers, they are simply there to keep the connection open. Events have this structure:


### PR DESCRIPTION
The API endpoints for the direct messages timeline and the direct messages streaming weren't documented.
I added them to the documentation.