### PR TITLE
Access-Control-Allow-Origin for web resources

### DIFF
--- a/Running-Mastodon/Production-guide.md
+++ b/Running-Mastodon/Production-guide.md
@@ -254,6 +254,7 @@ server {
 
   location ~ ^/(emoji|packs|system/accounts/avatars|system/media_attachments/files) {
     add_header Cache-Control "public, max-age=31536000, immutable";
+    add_header 'Access-Control-Allow-Origin' '*';
     try_files $uri @proxy;
   }
   


### PR DESCRIPTION
If we want to embeed a toot on a website, we need to allow external resources to be loaded, otherwise browser will block it with CORS.

```
Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at https://toots.benpro.fr/packs/common-0400b2a12246408ec6f5.js. (Reason: CORS header ‘Access-Control-Allow-Origin’ missing).
```