### PR TITLE
[enh] Doc for email

### DIFF
--- a/Running-Mastodon/Production-guide.md
+++ b/Running-Mastodon/Production-guide.md
@@ -518,12 +518,14 @@ It may be easier to use a subdomain to setup your email with a custom provider -
 Once you create your account, follow the instructions each provider gives you for updating your DNS records.  Once you have all the information ready to go and the service validates your DNS configuration, edit your config file.  These records should already exist in the configuration, but here's a sample setup that uses Mailgun that you can replace with your own personal info:
 
 ```
-SMTP_SERVER=smtp.mailgun.org
+SMTP_SERVER=smtp.domain.tld
 SMTP_PORT=587
-SMTP_LOGIN=anAccountThatIsntPostmaster@mstdn.domain.com
-SMTP_PASSWORD=HolySnacksAPassword
+SMTP_LOGIN='username'
+SMTP_PASSWORD='password'
 SMTP_FROM_ADDRESS=Domain.com Mastodon Admin <notifications@domain.com>
 ```
+
+Username and password must be kept between quote `' '`.
 
 Finally, to test this, spin up a Rails console (see [the administration guide](https://github.com/tootsuite/documentation/blob/master/Running-Mastodon/Administration-guide.md)) and run the following commands to test this out:
 

--- a/Running-Mastodon/Production-guide.md
+++ b/Running-Mastodon/Production-guide.md
@@ -534,6 +534,12 @@ m = UserMailer.new.mail to:'email@address.com', subject: 'test', body: 'awoo'
 m.deliver
 ```
 
+After modification and test, you will have to restart service on your server to be sure every changes are kept.
+
+```
+systemctl stop nginx
+```
+
 That is all! If everything was done correctly, a [Mastodon](https://github.com/tootsuite/mastodon/) instance will appear when you visit `https://example.com` in a web browser.
 
 Congratulations and welcome to the fediverse!

--- a/Running-Mastodon/Production-guide.md
+++ b/Running-Mastodon/Production-guide.md
@@ -537,7 +537,7 @@ m.deliver
 After modification and test, you will have to restart service on your server to be sure every changes are kept.
 
 ```
-systemctl stop nginx
+systemctl stop mastodon-*
 ```
 
 That is all! If everything was done correctly, a [Mastodon](https://github.com/tootsuite/mastodon/) instance will appear when you visit `https://example.com` in a web browser.

--- a/Running-Mastodon/Production-guide.md
+++ b/Running-Mastodon/Production-guide.md
@@ -537,7 +537,7 @@ m.deliver
 After modification and test, you will have to restart service on your server to be sure every changes are kept.
 
 ```
-systemctl stop mastodon-*
+systemctl stop mastodon-* && systemctl start mastodon-*
 ```
 
 That is all! If everything was done correctly, a [Mastodon](https://github.com/tootsuite/mastodon/) instance will appear when you visit `https://example.com` in a web browser.


### PR DESCRIPTION
## Problem : 

- I tried without quote as it seems to be in the doc, and it didn't works. I think special symbol in pass is not escaped.
- Ad for MailGun without real need ? (add confusion too for users or companies which may have their own SMTP Server)

## Solution : 

- Add ' ' in doc to be sure every user will understand.
- Add generic name for SMTP Server

(Perhaps can be good to add big SMTP server case like MailGun, and others.)