### PR TITLE
Clarify the certbot step for nginx

### DIFF
--- a/Running-Mastodon/Production-guide.md
+++ b/Running-Mastodon/Production-guide.md
@@ -342,7 +342,7 @@ After that successfully completes, we will use the webroot method. This requires
 
 ```sh
 systemctl start nginx
-# The certbot tool will ask if you want issue a new cert, please choose that option
+# The certbot tool will ask if you want to keep the existing certificate or renew it. Choose to renew it.
 certbot certonly --webroot -d example.com -w /home/mastodon/live/public/
 ```
 


### PR DESCRIPTION
The current comment says that you need to cheese to create a new cert. However, certbot gives you the following options:

    What would you like to do?
    -------------------------------------------------------------------------------
    1: Keep the existing certificate for now
    2: Renew & replace the cert (limit ~5 per 7 days)
    -------------------------------------------------------------------------------

It's not clear that renewing & replacing means to create a new one