### PR TITLE
Update Halcyon link

### DIFF
--- a/Using-Mastodon/Apps.md
+++ b/Using-Mastodon/Apps.md
@@ -114,7 +114,7 @@ List of apps
 
 |App|Source code|Developer(s)|
 |---|-----------|------------|
-|**[Halcyon](https://halcyon.toromino.de)**|<https://notabug.org/halcyon-suite/halcyon>|[@halcyon@social.csswg.org](https://social.csswg.org/@halcyon)|
+|**[Halcyon](https://notabug.org/halcyon-suite/halcyon/wiki/Instances)**|<https://notabug.org/halcyon-suite/halcyon>|[@halcyon@social.csswg.org](https://social.csswg.org/@halcyon)|
 |[Naumanni](https://naumanni.com/) *(alpha)*|<https://github.com/naumanni/naumanni>|[@shi3z@mstdn.onosendai.jp](https://mstdn.onosendai.jp/@shi3z)/[@shn@oppai.tokyo](https://oppai.tokyo/@shn)|
 |[Pinafore](https://pinafore.social/) *(beta)*|<https://github.com/nolanlawson/pinafore>|[@nolan@toot.cafe](https://toot.cafe/@nolan)|
 |[Brutaldon](https://brutaldon.online/)|<https://github.com/jfmcbrayer/brutaldon>|[@gcupc@glitch.social](https://glitch.social/@gcupc)|


### PR DESCRIPTION
https://halcyon.toromino.de is outdated. Replace with the official list of instances https://notabug.org/halcyon-suite/halcyon/wiki/Instances