### PR TITLE
Libraries: Replace mastodon-cpp with mastodonpp.

### DIFF
--- a/content/en/client/libraries.md
+++ b/content/en/client/libraries.md
@@ -21,7 +21,7 @@ menu:
 
 ## C++ <a id="c"></a>
 
-* [mastodon-cpp](https://github.com/tastytea/mastodon-cpp)
+* [mastodonpp](https://schlomp.space/tastytea/mastodonpp)
 
 ## Crystal <a id="crystal"></a>
 


### PR DESCRIPTION
[mastodon-cpp](https://github.com/tastytea/mastodon-cpp) is not actively maintained anymore and has been replaced by [mastodonpp](https://schlomp.space/tastytea/mastodonpp).