### PR TITLE
Add missing command to export key from gpg to apt

### DIFF
--- a/content/en/admin/optional/tor.md
+++ b/content/en/admin/optional/tor.md
@@ -22,6 +22,7 @@ Next add the gpg key.
 
 ```bash
 curl https://deb.torproject.org/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc | gpg --import
+gpg --export A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89 | apt-key add -
 ```
 
 Finally install the required packages.


### PR DESCRIPTION
A command was missing that's necessary to install the packages properly - the command to export the key used to sign the Tor packages from the gpg keyring to apt, which then allows apt to actually update with the tor repositories.