### PR TITLE
Fix 'bundle config' commands

### DIFF
--- a/content/en/admin/install.md
+++ b/content/en/admin/install.md
@@ -138,8 +138,8 @@ git checkout $(git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1)
 Now to install Ruby and JavaScript dependencies:
 
 ```bash
-bundle config set deployment 'true'
-bundle config set without 'development test'
+bundle config deployment 'true'
+bundle config without 'development test'
 bundle install -j$(getconf _NPROCESSORS_ONLN)
 yarn install --pure-lockfile
 ```


### PR DESCRIPTION
Hi,

this PR fixes the `bundle config` invocations.

Running the second `bundle config` command as it currently is in the docs results in a warning:
```bash
$ bundle config set deployment 'true'
$ bundle config set without 'development test'
You are replacing the current global value of set, which is currently "deployment true"
```

Apparently the `set` subcommand has been removed and instead the value will automatically be set if supplied and returned if only the key is supplied.