### PR TITLE
[WIP] Add documentation for emoji export command

### DIFF
--- a/content/en/admin/tootctl.md
+++ b/content/en/admin/tootctl.md
@@ -286,7 +286,7 @@ Imports custom emoji from a .tar.gz archive at a given path. The archive should 
 
 ### `tootctl emoji export` {#emoji-export}
 
-Exports custom emoji to a .tar.gz archive at a given path. The archive will be named `export.tar.gz`. By default, all emoji are exported.
+Exports custom emoji to a .tar.gz archive at a given path. The archive will be named `export.tar.gz`. By default, all emoji will be exported.
 
 **Version history:**
 `TBD` - added
@@ -295,7 +295,6 @@ Exports custom emoji to a .tar.gz archive at a given path. The archive will be n
 | :--- | :--- |
 | `PATH` | Path to an existing folder where the archive will be placed. Can be relative but has to exist. |
 | `--overwrite` | Overwrites an already existing archive. |
-| `--shortcode` | Uses the emoji shortcode as image file name instead of the original file name. |
 | `--category CATEGORY` | Only exports a specific category. Errors when no matching category was found. |
 
 ### `tootctl emoji purge` {#emoji-purge}

--- a/content/en/admin/tootctl.md
+++ b/content/en/admin/tootctl.md
@@ -284,6 +284,20 @@ Imports custom emoji from a .tar.gz archive at a given path. The archive should 
 | `--unlisted` | Processed emoji will not be shown in the emoji picker, but will be usable only by their direct shortcode. |
 | `--category CATEGORY` | Group the processed emoji under CATEGORY in the picker. |
 
+### `tootctl emoji export` {#emoji-export}
+
+Exports custom emoji to a .tar.gz archive at a given path. The archive will be named `export.tar.gz`. By default, all emoji are exported.
+
+**Version history:**
+`TBD` - added
+
+| Option | Description |
+| :--- | :--- |
+| `PATH` | Path to an existing folder where the archive will be placed. Can be relative but has to exist. |
+| `--overwrite` | Overwrites an already existing archive. |
+| `--shortcode` | Uses the emoji shortcode as image file name instead of the original file name. |
+| `--category CATEGORY` | Only exports a specific category. Errors when no matching category was found. |
+
 ### `tootctl emoji purge` {#emoji-purge}
 
 Remove all custom emoji.

--- a/content/en/admin/tootctl.md
+++ b/content/en/admin/tootctl.md
@@ -286,7 +286,8 @@ Imports custom emoji from a .tar.gz archive at a given path. The archive should 
 
 ### `tootctl emoji export` {#emoji-export}
 
-Exports custom emoji to a .tar.gz archive at a given path. The archive will be named `export.tar.gz`. By default, all emoji will be exported.
+Exports custom emoji to a .tar.gz archive at a given path. The archive will be named `export.tar.gz`.
+By default, all emoji will be exported.
 
 **Version history:**
 `TBD` - added


### PR DESCRIPTION
This PR adds documentation for the `tootctl emoji export` command introduced in [#13534](https://github.com/tootsuite/mastodon/pull/13534).

As the PR in tootsuite/mastodon is not yet released, the "added" part of the docs is `TBD`.