### PR TITLE
Change json.dumps to json.loads

### DIFF
--- a/content/en/client/public.md
+++ b/content/en/client/public.md
@@ -65,7 +65,7 @@ import requests
 import json
 
 response = requests.get("https://mastodon.example/api/v1/timelines/tag/cats?limit=2")
-statuses = json.dumps(response.text) # this converts the json to a python list of dictionary
+statuses = json.loads(response.text) # this converts the json to a python list of dictionary
 assert statuses[0]["visibility"] == "public" # we are reading a public timeline
 print(statuses[0]["content"]) # this prints the status text
 ```


### PR DESCRIPTION
`json.dumps` converts JSON to Python string which is not what's needed here. If `json.dumps` is used, `statuses[0]` becomes `"`.