### PR TITLE
Restore Docker guide from the 'archive' branch

### DIFF
--- a/content/en/admin/docker.md
+++ b/content/en/admin/docker.md
@@ -1,3 +1,12 @@
+---
+title: Installing with Docker
+description: Instructional guide on using Docker and docker-compose to run Mastodon
+menu:
+  docs:
+    weight: 20
+    parent: admin
+---
+
 ## Docker
 
 [![](https://images.microbadger.com/badges/version/tootsuite/mastodon.svg)](https://microbadger.com/images/tootsuite/mastodon "Get your own version badge on microbadger.com") [![](https://images.microbadger.com/badges/image/tootsuite/mastodon.svg)](https://microbadger.com/images/tootsuite/mastodon "Get your own image badge on microbadger.com")


### PR DESCRIPTION
WIP, as the install in docker is currently broken ( https://pastebin.com/raw/trpk4QC5 )

I also didn't try building it because I don't have the right hugo version on my system