### PR TITLE
Remove YouTube

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -6,7 +6,7 @@ menu:
     weight: -99
 ---
 
-{{< youtube id="IPSbNdBmWKE" caption="An introductory video explaining basic Mastodon concepts with visual animations" >}}
+{{< peertube id="7a087e5f-68e0-4359-8035-bfd9752e9b2e" caption="An introductory video explaining basic Mastodon concepts with visual animations" instance="peertube.social" >}}
 
 ## What is a microblog? {#microblogging}
 

--- a/content/en/entities/card.md
+++ b/content/en/entities/card.md
@@ -18,7 +18,7 @@ menu:
   "author_url": "https://peertube.social/video-channels/opensource@peertube.togart.de",
   "provider_name": "Peertube",
   "provider_url": "https://peertube.social",
-  "html": "<iframe width="560" height="315" sandbox=\"allow-same-origin allow-scripts allow-popups\" src=\"https://peertube.social/videos/embed/7a087e5f-68e0-4359-8035-bfd9752e9b2e\" frameborder=\"0\" allowfullscreen></iframe>",
+  "html": "<iframe width='480' height='270' sandbox='allow-same-origin allow-scripts allow-popups' src='https://peertube.social/videos/embed/7a087e5f-68e0-4359-8035-bfd9752e9b2e' frameborder='0' allowfullscreen></iframe>",
   "width": 480,
   "height": 270,
   "image": "https://peertube.social/static/previews/7a087e5f-68e0-4359-8035-bfd9752e9b2e.jpg",

--- a/content/en/entities/card.md
+++ b/content/en/entities/card.md
@@ -10,18 +10,18 @@ menu:
 {{< tab title="video" >}}
 ```javascript
 {
-  "url": "https://www.youtube.com/watch?v=OMv_EPMED8Y",
-  "title": "♪ Brand New Friend (Christmas Song!)",
+  "url": "https://peertube.social/videos/watch/7a087e5f-68e0-4359-8035-bfd9752e9b2e",
+  "title": "What is Mastodon ?",
   "description": "",
   "type": "video",
-  "author_name": "YOGSCAST Lewis & Simon",
-  "author_url": "https://www.youtube.com/user/BlueXephos",
-  "provider_name": "YouTube",
-  "provider_url": "https://www.youtube.com/",
-  "html": "<iframe width=\"480\" height=\"270\" src=\"https://www.youtube.com/embed/OMv_EPMED8Y?feature=oembed\" frameborder=\"0\" allowfullscreen=\"\"></iframe>",
+  "author_name": "Opensource",
+  "author_url": "https://peertube.social/video-channels/opensource@peertube.togart.de",
+  "provider_name": "Peertube",
+  "provider_url": "https://peertube.social",
+  "html": "<iframe width="560" height="315" sandbox=\"allow-same-origin allow-scripts allow-popups\" src=\"https://peertube.social/videos/embed/7a087e5f-68e0-4359-8035-bfd9752e9b2e\" frameborder=\"0\" allowfullscreen></iframe>",
   "width": 480,
   "height": 270,
-  "image": "https://files.mastodon.social/preview_cards/images/014/179/145/original/9cf4b7cf5567b569.jpeg",
+  "image": "https://peertube.social/static/previews/7a087e5f-68e0-4359-8035-bfd9752e9b2e.jpg",
   "embed_url": ""
 }
 ```

--- a/content/en/methods/statuses.md
+++ b/content/en/methods/statuses.md
@@ -1490,7 +1490,7 @@ ID of the status in the database
   "author_url": "https://peertube.social/video-channels/opensource@peertube.togart.de",
   "provider_name": "Peertube",
   "provider_url": "https://peertube.social",
-  "html": "<iframe width="560" height="315" sandbox=\"allow-same-origin allow-scripts allow-popups\" src=\"https://peertube.social/videos/embed/7a087e5f-68e0-4359-8035-bfd9752e9b2e\" frameborder=\"0\" allowfullscreen></iframe>",
+  "html": "<iframe width='480' height='270' sandbox='allow-same-origin allow-scripts allow-popups' src='https://peertube.social/videos/embed/7a087e5f-68e0-4359-8035-bfd9752e9b2e' frameborder='0' allowfullscreen></iframe>",
   "width": 480,
   "height": 270,
   "image": "https://peertube.social/static/previews/7a087e5f-68e0-4359-8035-bfd9752e9b2e.jpg",

--- a/content/en/methods/statuses.md
+++ b/content/en/methods/statuses.md
@@ -1482,18 +1482,18 @@ ID of the status in the database
 
 ```javascript
 {
-  "url": "https://www.youtube.com/watch?v=OMv_EPMED8Y",
-  "title": "♪ Brand New Friend (Christmas Song!)",
+  "url": "https://peertube.social/videos/watch/7a087e5f-68e0-4359-8035-bfd9752e9b2e",
+  "title": "What is Mastodon ?",
   "description": "",
   "type": "video",
-  "author_name": "YOGSCAST Lewis & Simon",
-  "author_url": "https://www.youtube.com/user/BlueXephos",
-  "provider_name": "YouTube",
-  "provider_url": "https://www.youtube.com/",
-  "html": "<iframe width=\"480\" height=\"270\" src=\"https://www.youtube.com/embed/OMv_EPMED8Y?feature=oembed\" frameborder=\"0\" allowfullscreen=\"\"></iframe>",
+  "author_name": "Opensource",
+  "author_url": "https://peertube.social/video-channels/opensource@peertube.togart.de",
+  "provider_name": "Peertube",
+  "provider_url": "https://peertube.social",
+  "html": "<iframe width="560" height="315" sandbox=\"allow-same-origin allow-scripts allow-popups\" src=\"https://peertube.social/videos/embed/7a087e5f-68e0-4359-8035-bfd9752e9b2e\" frameborder=\"0\" allowfullscreen></iframe>",
   "width": 480,
   "height": 270,
-  "image": "https://files.mastodon.social/preview_cards/images/014/179/145/original/9cf4b7cf5567b569.jpeg",
+  "image": "https://peertube.social/static/previews/7a087e5f-68e0-4359-8035-bfd9752e9b2e.jpg",
   "embed_url": ""
 }
 ```

--- a/layouts/shortcodes/peertube.html
+++ b/layouts/shortcodes/peertube.html
@@ -1,0 +1,10 @@
+<figure>
+    <div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
+      <iframe src='https://{{- .Get "instance"}}/videos/embed/{{ .Get "id" }}' style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;" allowfullscreen title="{{ .Get "caption" }}"></iframe>
+    </div>
+  
+    <figcaption>
+      <p>{{- .Get "caption" | markdownify -}}</p>
+    </figcaption>
+  </figure>
+  


### PR DESCRIPTION
This commit removes several references to YouTube, and the main YouTube video on the home page.

This greatly improves privacy, and removes Mastodon's dependency on YouTube for the introduction. Instead, users are introduced to the safer alternative: Peertube. This is a victory for privacy, as Peertube does not collect data on users. Trusting Google to respect people's privacy is naive, [as they have abused this trust repeatedly in the past.](https://thenextweb.com/apps/2020/06/04/google-chrome-tracking-incognito-mode-lawsuit/)