### PR TITLE
Add troubleshooting for compilation error

### DIFF
--- a/content/en/admin/troubleshooting.md
+++ b/content/en/admin/troubleshooting.md
@@ -28,4 +28,4 @@ Check that you are specifying the correct environment with `RAILS_ENV=production
 
 ## **I encountered a compilation error while executing `RAILS_ENV=production bundle exec rails assets:precompile`, but no more information is given. How to fix it?**
 
-Usually it's because your server ran out of memory while compiling assets. Use something like a swapfile to increase the memory capacity.
+Usually it's because your server ran out of memory while compiling assets. Use a swapfile or increase the swap space to increase the memory capacity.

--- a/content/en/admin/troubleshooting.md
+++ b/content/en/admin/troubleshooting.md
@@ -26,3 +26,6 @@ Check that you have run `RAILS_ENV=production bin/rails db:migrate` after the up
 
 Check that you are specifying the correct environment with `RAILS_ENV=production` before the command. By default, the environment is assumed to be development, so the code tries to load development-related gems. However, in production environments, we avoid installing those gems, and that’s where the error comes from.
 
+## **I encountered a compilation error while executing `RAILS_ENV=production bundle exec rails assets:precompile`, but no more information is given. How to fix it?**
+
+Usually it's because your server ran out of memory while compiling assets. Use something like a swapfile to increase the memory capacity.


### PR DESCRIPTION
I have seen multiple server admins complained about compilation error without an error message. Usually it's just because the server has run out of memory and swap. It would be helpful to add this message into the document.