### PR TITLE
Further improve troubleshooting page

### DIFF
--- a/content/en/admin/troubleshooting.md
+++ b/content/en/admin/troubleshooting.md
@@ -28,4 +28,4 @@ Check that you are specifying the correct environment with `RAILS_ENV=production
 
 ## **I encountered a compilation error while executing `RAILS_ENV=production bundle exec rails assets:precompile`, but no more information is given. How to fix it?**
 
-Usually it's because your server ran out of memory while compiling assets. Use a swapfile or increase the swap space to increase the memory capacity.
+Usually it's because your server ran out of memory while compiling assets. Use a swapfile or increase the swap space to increase the memory capacity. Run `RAILS_ENV=production bundle exec rake tmp:cache:clear` to clear cache, then execute `RAILS_ENV=production bundle exec rails assets:precompile` to compile again.

--- a/content/en/admin/troubleshooting.md
+++ b/content/en/admin/troubleshooting.md
@@ -28,4 +28,4 @@ Check that you are specifying the correct environment with `RAILS_ENV=production
 
 ## **I encountered a compilation error while executing `RAILS_ENV=production bundle exec rails assets:precompile`, but no more information is given. How to fix it?**
 
-Usually it's because your server ran out of memory while compiling assets. Use a swapfile or increase the swap space to increase the memory capacity. Run `RAILS_ENV=production bundle exec rake tmp:cache:clear` to clear cache, then execute `RAILS_ENV=production bundle exec rails assets:precompile` to compile again.
+Usually it's because your server ran out of memory while compiling assets. Use a swapfile or increase the swap space to increase the memory capacity. Run `RAILS_ENV=production bundle exec rake tmp:cache:clear` to clear cache, then execute `RAILS_ENV=production bundle exec rails assets:precompile` to compile again. Make sure you clear the cache after a compilation error, or it will show "Everything's OK" but leave the assets unchanged.


### PR DESCRIPTION
### Change

Added one line to resolve compilation error.

### Reason
From my own experience, if the compilation got interrupted because of insufficient memory, the admin must clear the cache before they compile again. Otherwise it will show "Everything's OK, nothing to do", but the assets are compiled.