### PR TITLE
fix: systemctl enable mastodon-* does not always work

### DIFF
--- a/content/en/admin/install.md
+++ b/content/en/admin/install.md
@@ -214,7 +214,7 @@ Finally, start and enable the new systemd services:
 ```bash
 systemctl daemon-reload
 systemctl start mastodon-web mastodon-sidekiq mastodon-streaming
-systemctl enable mastodon-*
+systemctl enable mastodon-web mastodon-sidekiq mastodon-streaming
 ```
 
 They will now automatically start at boot time.


### PR DESCRIPTION
```
root@ubuntu:# systemctl enable mastodon-*
Failed to enable unit: Unit file mastodon-\x2a.service does not exist.
root@ubuntu:# systemctl enable mastodon-web mastodon-sidekiq mastodon-streaming
Created symlink /etc/systemd/system/multi-user.target.wants/mastodon-web.service → /etc/systemd/system/mastodon-web.service.
Created symlink /etc/systemd/system/multi-user.target.wants/mastodon-sidekiq.service → /etc/systemd/system/mastodon-sidekiq.service.
Created symlink /etc/systemd/system/multi-user.target.wants/mastodon-streaming.service → /etc/systemd/system/mastodon-streaming.service.
```