### PR TITLE
Change S3 access style

### DIFF
--- a/content/en/admin/optional/object-storage-proxy.md
+++ b/content/en/admin/optional/object-storage-proxy.md
@@ -29,7 +29,7 @@ server {
     try_files $uri @s3;
   }
 
-  set $s3_backend 'https://YOUR_S3_HOSTNAME';
+  set $s3_backend 'https://YOUR_BUCKET_NAME.YOUR_S3_HOSTNAME';
 
   location @s3 {
     limit_except GET {
@@ -51,7 +51,7 @@ server {
     proxy_hide_header x-amz-bucket-region;
     proxy_hide_header x-amzn-requestid;
     proxy_ignore_headers Set-Cookie;
-    proxy_pass $s3_backend/YOUR_BUCKET_NAME$uri;
+    proxy_pass $s3_backend$uri;
     proxy_intercept_errors off;
 
     proxy_cache CACHE;


### PR DESCRIPTION
Amazon has announced that it's changing S3 access style.
"path-style access" is no longer supported by buckets created after September 30, 2020.

For more information, please refer to links below.
https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html
https://aws.amazon.com/jp/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/