### PR TITLE
Fix typo in filename introduced in #801

### DIFF
--- a/content/en/entities/relationship.md
+++ b/content/en/entities/relationship.md
@@ -112,7 +112,7 @@ menu:
 
 ## See also
 
-* [GET /api/v1/accounts/relationships]({{< relref "../methods/accounts.d#check-relationships-to-other-accounts" >}})
+* [GET /api/v1/accounts/relationships]({{< relref "../methods/accounts.md#check-relationships-to-other-accounts" >}})
 
 {{< caption-link url="https://github.com/tootsuite/mastodon/blob/master/app/serializers/rest/relationship_serializer.rb" caption="app/serializers/rest/relationship\_serializer.rb" >}}
 


### PR DESCRIPTION
A typo in one filename introduced itself in #801 and was brought up via this failed test: https://github.com/tootsuite/documentation/actions/runs/203082062. This fixed.

Sidenote: interestingly it doesn't fail when building it using `Hugo Static Site Generator v0.74.3/extended`-