### PR TITLE
feat: add a section on periodic cleanup tasks

### DIFF
--- a/content/en/admin/setup.md
+++ b/content/en/admin/setup.md
@@ -44,3 +44,19 @@ After logging in, navigate to the **Site settings** page. While there are no tec
 
 After you fill these in, simply hit “Save changes”.
 
+## Running periodic cleanup tasks {#cleanup}
+
+Mastodon generates some temporary files that are worth cleaning up after a certain amount of time (e.g. to save money on hosting). In general, you want to set up `cron` jobs (or another mechanism) to run these periodic cleanup tasks.
+
+Typically you want to run [`tootctl media remove`](https://docs.joinmastodon.org/admin/tootctl/#media) and [`tootctl preview_cards remove`](https://docs.joinmastodon.org/admin/tootctl/#preview_cards) periodically. These will clean up remote media (e.g. images, videos, audio) and preview cards (e.g. preview images for links) after a certain number of days. (Check the docs for those commands if you want to tweak how old something has to be before it's cleaned up.)
+
+First, run `crontab -e` to edit the cronfile for the `mastodon` user. (If you get a prompt asking which editor to use, choose your favorite editor.)
+
+Next, add something like the following to the bottom of the file:
+
+    @weekly RAILS_ENV=production /home/malftech/live/bin/tootctl media remove
+    @weekly RAILS_ENV=production /home/malftech/live/bin/tootctl preview_cards remove
+
+This will run these two commands on a weekly basis.
+
+Finally, save the file. You can use `crontab -l` to verify the configuration.

--- a/content/en/admin/setup.md
+++ b/content/en/admin/setup.md
@@ -54,8 +54,8 @@ First, run `crontab -e` to edit the cronfile for the `mastodon` user. (If you ge
 
 Next, add something like the following to the bottom of the file:
 
-    @weekly RAILS_ENV=production /home/malftech/live/bin/tootctl media remove
-    @weekly RAILS_ENV=production /home/malftech/live/bin/tootctl preview_cards remove
+    @weekly RAILS_ENV=production /home/mastodon/live/bin/tootctl media remove
+    @weekly RAILS_ENV=production /home/mastodon/live/bin/tootctl preview_cards remove
 
 This will run these two commands on a weekly basis.
 


### PR DESCRIPTION
I asked in Discord today about which `tootctl` tasks are good to run on a regular basis (as there are a lot of cleanup jobs). It seems that `media remove` and `preview_cards remove` are the standard ones that you want to run on a regular basis (e.g. with cron). So I added this to the docs in its own section, under "Things to do after installing Mastodon."