### PR TITLE
Update dependencies

### DIFF
--- a/content/en/admin/install.md
+++ b/content/en/admin/install.md
@@ -40,7 +40,7 @@ apt install -y \
   imagemagick ffmpeg libpq-dev libxml2-dev libxslt1-dev file git-core \
   g++ libprotobuf-dev protobuf-compiler pkg-config nodejs gcc autoconf \
   bison build-essential libssl-dev libyaml-dev libreadline6-dev \
-  zlib1g-dev libncurses5-dev libffi-dev libgdbm5 libgdbm-dev \
+  zlib1g-dev libncurses5-dev libffi-dev libgdbm-dev \
   nginx redis-server redis-tools postgresql postgresql-contrib \
   certbot python-certbot-nginx yarn libidn11-dev libicu-dev libjemalloc-dev
 ```


### PR DESCRIPTION
Installing `libgdbm5` gave me an error on Ubuntu 18.04 upwards. `libgdbm-dev` already installs the necessary version of libgdbm automatically, we don't have to hardcode this.