### PR TITLE
fix: fix PATH in periodic cleanup cron jobs

### DIFF
--- a/content/en/admin/setup.md
+++ b/content/en/admin/setup.md
@@ -54,8 +54,8 @@ First, run `crontab -e` to edit the cronfile for the `mastodon` user. (If you ge
 
 Next, add something like the following to the bottom of the file:
 
-    @weekly RAILS_ENV=production /home/mastodon/live/bin/tootctl media remove
-    @weekly RAILS_ENV=production /home/mastodon/live/bin/tootctl preview_cards remove
+    @weekly PATH=/home/mastodon/.rbenv/shims:/home/mastodon/.rbenv/bin:/usr/local/bin:/usr/bin:/bin RAILS_ENV=production /home/mastodon/live/bin/tootctl media remove
+    @weekly PATH=/home/mastodon/.rbenv/shims:/home/mastodon/.rbenv/bin:/usr/local/bin:/usr/bin:/bin RAILS_ENV=production /home/mastodon/live/bin/tootctl preview_cards remove
 
 This will run these two commands on a weekly basis.
 


### PR DESCRIPTION
I realized that my cron jobs were not actually running because I needed to add rbenv to the `PATH`. Good way to waste money – holding onto S3 files I don't need anymore!

Hopefully this will help other Mastodon admins from making the same mistake.