### PR TITLE
Readme and Install update 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,123 @@
 ![Mastodon](https://i.imgur.com/NhZc40l.png)
-====
+===
 
-View the documentation at <https://docs.joinmastodon.org>
+# Doc site
+
+This is the documentation site for the federated social network Mastodon.
+View the live version at <https://docs.joinmastodon.org>.
+The doc site, docs.joinmastodon.org, is made using the static-site generator Hugo.
+Clone tootsuite/documentation and install Hugo to begin contributing.
+
+# Getting started
+
+Install [Hugo](https://gohugo.io/) and clone the repository to get started.
+
+## Install Hugo
+
+### Linux
+
+For Debian based distributions, such as Ubuntu, use apt to install Hugo:
+
+```bash
+sudo apt-get install hugo
+```
+
+### MacOS
+
+Use Homebrew to install Hugo:
+
+```bash
+brew install hugo
+```
+### Windows
+
+Windows users may choose from [Chocolatey](https://chocolatey.org/):
+
+```
+choco install hugo -confirm
+```
+
+``` 
+scoop install hugo
+```
+
+## Run Hugo server 
+
+The easiest way to view the final product as you document is to run:
+
+```bash
+hugo server
+```
+
+This will launch a Hugo server that will dynamically rebuild based on [published pages](#publish-pages).
+Use the ``-D`` flag to view drafts and unpublished changes as we write and design. 
+
+```bash
+hugo server -D
+```
+
+**Note:**
+
+Some changes may take longer or require you to enable Slow Render Mode:
+
+```bash
+hugo server --disableFastRender
+```
+
+## Content
+
+All content is written in GitHub flavored Markdown. 
+See https://github.github.com/gfm/ for more information.
+Every page begins with a YAML header that is generated through Hugo.
+*Using Hugo to generate a new page is strongly recommend to ensure that the YAML header includes required information.*
+
+### Directory structure
+
+All content rendered by Hugo is stored under the content/ folder.
+*For English*, all content is stored under content/en/.
+For details on content organization, see [Content Organization](https://gohugo.io/content-management/organization/) on the https://gohugo.io  site.
+
+### Add a page
+
+Do not simply add a file, instead generate a file to edit using Hugo:
+
+In the site's root directory run 
+
+```bash
+hugo new [Path and filename].md
+```
+
+This will create a new file and folder (if no folder was present).
+
+**Example:**
+
+```bash
+$ hugo new posts/test.md
+content/en/posts/test.md created
+```
+
+Once the page is created, you can begin to write by opening the newly created file in your favorite text editor.
+
+### Editing a page
+
+Editing is much more simple, simply find the existing file and make changes in your text editor.
+To review your changes, ensure that you have the [Hugo server running](#run-hugo-server).
+
+### Publish pages
+
+Hugo determines draft state in its meta header.
+
+```yaml
+---
+title: "Test"
+date: YYYY-MM-DD 
+draft: true
+---
+
+```
+The ``draft`` boolean determines  draft state.
+If ``draft`` is ``true`` then the page will not display be default with the standard ``hugo server`` command.
+Drafts may be viewed by running ``hugo server -D``.
+To publish a draft, set ``draft`` to ``false``.
+
+

--- a/content/en/admin/install.md
+++ b/content/en/admin/install.md
@@ -1,6 +1,6 @@
 ---
-title: Installing from source
-description: Instructional guide on creating your own Mastodon-powered website.
+title: Install from source
+description: Host your own Mastodon instance
 menu:
   docs:
     weight: 20
@@ -42,7 +42,7 @@ apt install -y \
   bison build-essential libssl-dev libyaml-dev libreadline6-dev \
   zlib1g-dev libncurses5-dev libffi-dev libgdbm-dev \
   nginx redis-server redis-tools postgresql postgresql-contrib \
-  certbot python-certbot-nginx yarn libidn11-dev libicu-dev libjemalloc-dev
+  certbot python3-certbot-nginx yarn libidn11-dev libicu-dev libjemalloc-dev
 ```
 
 ### Installing Ruby {#installing-ruby}
@@ -72,6 +72,7 @@ git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-build
 
 Once this is done, we can install the correct Ruby version:
 
+
 ```bash
 RUBY_CONFIGURE_OPTS=--with-jemalloc rbenv install 2.6.6
 rbenv global 2.6.6
@@ -93,13 +94,21 @@ exit
 
 ### Setting up PostgreSQL {#setting-up-postgresql}
 
+Install PostGreSQL
+
+```bash
+apt install postgresql
+```
+
 #### Performance configuration \(optional\) {#performance-configuration-optional}
 
-For optimal performance, you may use [pgTune](https://pgtune.leopard.in.ua/#/) to generate an appropriate configuration and edit values in `/etc/postgresql/9.6/main/postgresql.conf` before restarting PostgreSQL with `systemctl restart postgresql`
+For optimal performance, you may use PostGreSQL with custom configuration values from [pgTune](https://pgtune.leopard.in.ua/#/) to generate an appropriate configuration. Paste parameters and edit values in `/etc/postgresql/12/main/postgresql.conf` before restarting PostgreSQL with `systemctl restart postgresql`
 
 #### Creating a user {#creating-a-user}
 
-You will need to create a PostgreSQL user that Mastodon could use. It is easiest to go with “ident” authentication in a simple setup, i.e. the PostgreSQL user does not have a separate password and can be used by the Linux user with the same username.
+You will need to create a PostgreSQL user that Mastodon could use. It is easiest to go with “ident” authentication in a simple setup,
+where the PostGreSQL user credentials are shared with a Linux system user.
+The PostGreSQL user uses the same credentials to log in to Mastodon.
 
 Open the prompt:
 
@@ -114,11 +123,9 @@ CREATE USER mastodon CREATEDB;
 \q
 ```
 
-Done!
-
 ### Setting up Mastodon {#setting-up-mastodon}
 
-It is time to download the Mastodon code. Switch to the mastodon user:
+It is time to download the Mastodon code. Switch to the Mastodon user as root:
 
 ```bash
 su - mastodon
@@ -132,6 +139,8 @@ Use git to download the latest stable release of Mastodon:
 git clone https://github.com/tootsuite/mastodon.git live && cd live
 git checkout $(git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1)
 ```
+
+
 
 #### Installing the last dependencies {#installing-the-last-dependencies}
 

--- a/content/en/spec/activitypub.md
+++ b/content/en/spec/activitypub.md
@@ -356,3 +356,8 @@ Mastodon allows users to opt-in or opt-out of discoverability features like the 
 }
 ```
 
+### Secure mode {#secure-mode}
+
+When a Mastodon server runs in secure mode, all cross-server HTTP requests to it must be signed (in other words, even `GET` requests to public resources). That way, the Mastodon server can choose to reject requests from servers it has blocked and avoid "leaking" public information. Mastodon itself uses a dedicated system actor to sign such HTTP requests.
+
+Secure mode is the foundation upon which "limited federation mode" is built. A Mastodon server in limited federation mode will only federate with servers its admin has explicitly allowed, and reject all other requests.


### PR DESCRIPTION
Fixes #796 

Added instructions for setting up the documentation environment.
Primarily edited/created the readme. 

Note that I am on Ubuntu 20.04, rather than the default 18.04 specified in instructions.
This still worked all fine.