### PR TITLE
add identifier for troubleshooting pages

### DIFF
--- a/content/en/admin/troubleshooting.md
+++ b/content/en/admin/troubleshooting.md
@@ -4,6 +4,7 @@ menu:
   docs:
     weight: 120
     parent: admin
+    identifier: admin-troubleshooting
 ---
 
 ## **I see an error page that says something went wrong. How do I find out what’s wrong?**


### PR DESCRIPTION
without the identifier, the page on index corruption mistakenly appears at the bottom of the sidebar in its own section titled "admin-troubleshooting"