### PR TITLE
Remove broken link to Nablahost

### DIFF
--- a/content/en/user/run-your-own.md
+++ b/content/en/user/run-your-own.md
@@ -42,8 +42,6 @@ There exist a number of **dedicated Mastodon hosting providers** that take care 
 
 {{< caption-link url="https://app.spacebear.ee/mastodon" caption="Spacebear" >}}
 
-{{< caption-link url="https://nablahost.com/services/activitypub-hosting/" caption="Nablahost" >}}
-
 Managed hosting solutions are great for those who do not have experience or desire to install and maintain software. However, being in charge of all components on your own hardware gives greater control over scaling, performance and customization.
 
 We provide a **DigitalOcean 1-Click Install Image** that you can put on a DigitalOcean droplet of your choosing which essentially gives you everything you would otherwise have after following our installation instructions through an interactive setup wizard.


### PR DESCRIPTION
I couldn't find any information online about what happened to them, but [their domain](http://nablahost.com/) expired and is now owned by a domain squatter.


| ![image](https://user-images.githubusercontent.com/401283/104084862-18e12380-5219-11eb-9c28-a22a77091c6a.png) | ![image](https://user-images.githubusercontent.com/401283/104084860-14b50600-5219-11eb-9e1f-27e7e0fda0d0.png) |
| --- | --- |
| Before | After |


