### PR TITLE
Update prerequisites.md fail2ban settings

### DIFF
--- a/content/en/admin/prerequisites.md
+++ b/content/en/admin/prerequisites.md
@@ -36,6 +36,7 @@ port = 22
 [sshd-ddos]
 enabled = true
 port = 22
+filter = sshd
 ```
 
 Finally restart fail2ban:


### PR DESCRIPTION
I was getting an error similar to the one posted [here](https://serverfault.com/q/1034871/613055), namely the lines
```
Sep 22 17:06:29 twitter-builder fail2ban-server[7483]:  Found no accessible config files for 'filter.d/sshd-ddos' under /etc/fail2ban
Sep 22 17:06:29 twitter-builder fail2ban-server[7483]:  Unable to read the filter 'sshd-ddos'
Sep 22 17:06:29 twitter-builder fail2ban-server[7483]:  Errors in jail 'sshd-ddos'. Skipping...
```

This was solved by the [answer below](https://serverfault.com/a/1050315/613055), which this proposal adds to the documentation