### PR TITLE
Set host headers to match S3 backend

### DIFF
--- a/content/en/admin/optional/object-storage-proxy.md
+++ b/content/en/admin/optional/object-storage-proxy.md
@@ -37,7 +37,7 @@ server {
     }
 
     resolver 8.8.8.8;
-    proxy_set_header Host YOUR_S3_HOSTNAME;
+    proxy_set_header Host YOUR_BUCKET_NAME.YOUR_S3_HOSTNAME;
     proxy_set_header Connection '';
     proxy_set_header Authorization '';
     proxy_hide_header Set-Cookie;


### PR DESCRIPTION
While working through configuring a new mastodon instance to proxy its files to S3 as documented in this guide, I was able to upload files but got the following error when trying to view the uploaded file:

```
<Error>
<Code>PermanentRedirect</Code>
<Message>
The bucket you are attempting to access must be addressed using 
the specified endpoint. Please send all future requests to this
  endpoint.
</Message>
<Endpoint>s3.amazonaws.com</Endpoint>
<Bucket>accounts</Bucket>
<RequestId>C8WMVKGWXXXRK0WM</RequestId>
<HostId>
nvYMXifTCxqbb+nZr9XtHXxXxXisjtEax38K7/4JNqxGIFuvS8Pbjib+WlUQt6v+b1DGWGVVAA=
</HostId>
</Error>
```

This was a non-obvious error, so it took me a little while to realize it was due to the Host headers not matching in the request.

It appears this line was missed when updating to the new path style in https://github.com/tootsuite/documentation/pull/799. Hope this helps!