### PR TITLE
Add postgres dump file format specification for restore

### DIFF
--- a/content/en/admin/migrating.md
+++ b/content/en/admin/migrating.md
@@ -62,7 +62,7 @@ createdb -T template0 mastodon_production
 Then import it:
 
 ```bash
-pg_restore -U mastodon -n public --no-owner --role=mastodon \
+pg_restore -Fc -U mastodon -n public --no-owner --role=mastodon \
   -d mastodon_production backup.dump
 ```
 


### PR DESCRIPTION
As postgres document, `pg_restore` will automatically determine the format of the dump file. But when I ran it, it failed.

Since we use `-Fc` option at `pg_dump`, writing as so in `pg_restore` would be nice.